### PR TITLE
Use reexports.

### DIFF
--- a/library/Control/Applicative.hs
+++ b/library/Control/Applicative.hs
@@ -1,7 +1,0 @@
-module Control.Applicative
-(
-  module Rebase.Control.Applicative
-)
-where
-
-import Rebase.Control.Applicative

--- a/library/Control/Applicative/Backwards.hs
+++ b/library/Control/Applicative/Backwards.hs
@@ -1,7 +1,0 @@
-module Control.Applicative.Backwards
-(
-  module Rebase.Control.Applicative.Backwards
-)
-where
-
-import Rebase.Control.Applicative.Backwards

--- a/library/Control/Applicative/Lift.hs
+++ b/library/Control/Applicative/Lift.hs
@@ -1,7 +1,0 @@
-module Control.Applicative.Lift
-(
-  module Rebase.Control.Applicative.Lift
-)
-where
-
-import Rebase.Control.Applicative.Lift

--- a/library/Control/Arrow.hs
+++ b/library/Control/Arrow.hs
@@ -1,7 +1,0 @@
-module Control.Arrow
-(
-  module Rebase.Control.Arrow
-)
-where
-
-import Rebase.Control.Arrow

--- a/library/Control/Category.hs
+++ b/library/Control/Category.hs
@@ -1,7 +1,0 @@
-module Control.Category
-(
-  module Rebase.Control.Category
-)
-where
-
-import Rebase.Control.Category

--- a/library/Control/Comonad.hs
+++ b/library/Control/Comonad.hs
@@ -1,7 +1,0 @@
-module Control.Comonad
-(
-  module Rebase.Control.Comonad
-)
-where
-
-import Rebase.Control.Comonad

--- a/library/Control/Concurrent.hs
+++ b/library/Control/Concurrent.hs
@@ -1,7 +1,0 @@
-module Control.Concurrent
-(
-  module Rebase.Control.Concurrent
-)
-where
-
-import Rebase.Control.Concurrent

--- a/library/Control/Concurrent/Chan.hs
+++ b/library/Control/Concurrent/Chan.hs
@@ -1,7 +1,0 @@
-module Control.Concurrent.Chan
-(
-  module Rebase.Control.Concurrent.Chan
-)
-where
-
-import Rebase.Control.Concurrent.Chan

--- a/library/Control/Concurrent/MVar.hs
+++ b/library/Control/Concurrent/MVar.hs
@@ -1,7 +1,0 @@
-module Control.Concurrent.MVar
-(
-  module Rebase.Control.Concurrent.MVar
-)
-where
-
-import Rebase.Control.Concurrent.MVar

--- a/library/Control/Concurrent/QSem.hs
+++ b/library/Control/Concurrent/QSem.hs
@@ -1,7 +1,0 @@
-module Control.Concurrent.QSem
-(
-  module Rebase.Control.Concurrent.QSem
-)
-where
-
-import Rebase.Control.Concurrent.QSem

--- a/library/Control/Concurrent/QSemN.hs
+++ b/library/Control/Concurrent/QSemN.hs
@@ -1,7 +1,0 @@
-module Control.Concurrent.QSemN
-(
-  module Rebase.Control.Concurrent.QSemN
-)
-where
-
-import Rebase.Control.Concurrent.QSemN

--- a/library/Control/Concurrent/STM.hs
+++ b/library/Control/Concurrent/STM.hs
@@ -1,7 +1,0 @@
-module Control.Concurrent.STM
-(
-  module Rebase.Control.Concurrent.STM
-)
-where
-
-import Rebase.Control.Concurrent.STM

--- a/library/Control/Concurrent/STM/TArray.hs
+++ b/library/Control/Concurrent/STM/TArray.hs
@@ -1,7 +1,0 @@
-module Control.Concurrent.STM.TArray
-(
-  module Rebase.Control.Concurrent.STM.TArray
-)
-where
-
-import Rebase.Control.Concurrent.STM.TArray

--- a/library/Control/Concurrent/STM/TBQueue.hs
+++ b/library/Control/Concurrent/STM/TBQueue.hs
@@ -1,7 +1,0 @@
-module Control.Concurrent.STM.TBQueue
-(
-  module Rebase.Control.Concurrent.STM.TBQueue
-)
-where
-
-import Rebase.Control.Concurrent.STM.TBQueue

--- a/library/Control/Concurrent/STM/TChan.hs
+++ b/library/Control/Concurrent/STM/TChan.hs
@@ -1,7 +1,0 @@
-module Control.Concurrent.STM.TChan
-(
-  module Rebase.Control.Concurrent.STM.TChan
-)
-where
-
-import Rebase.Control.Concurrent.STM.TChan

--- a/library/Control/Concurrent/STM/TMVar.hs
+++ b/library/Control/Concurrent/STM/TMVar.hs
@@ -1,7 +1,0 @@
-module Control.Concurrent.STM.TMVar
-(
-  module Rebase.Control.Concurrent.STM.TMVar
-)
-where
-
-import Rebase.Control.Concurrent.STM.TMVar

--- a/library/Control/Concurrent/STM/TQueue.hs
+++ b/library/Control/Concurrent/STM/TQueue.hs
@@ -1,7 +1,0 @@
-module Control.Concurrent.STM.TQueue
-(
-  module Rebase.Control.Concurrent.STM.TQueue
-)
-where
-
-import Rebase.Control.Concurrent.STM.TQueue

--- a/library/Control/Concurrent/STM/TSem.hs
+++ b/library/Control/Concurrent/STM/TSem.hs
@@ -1,7 +1,0 @@
-module Control.Concurrent.STM.TSem
-(
-  module Rebase.Control.Concurrent.STM.TSem
-)
-where
-
-import Rebase.Control.Concurrent.STM.TSem

--- a/library/Control/Concurrent/STM/TVar.hs
+++ b/library/Control/Concurrent/STM/TVar.hs
@@ -1,7 +1,0 @@
-module Control.Concurrent.STM.TVar
-(
-  module Rebase.Control.Concurrent.STM.TVar
-)
-where
-
-import Rebase.Control.Concurrent.STM.TVar

--- a/library/Control/DeepSeq.hs
+++ b/library/Control/DeepSeq.hs
@@ -1,7 +1,0 @@
-module Control.DeepSeq
-(
-  module Rebase.Control.DeepSeq
-)
-where
-
-import Rebase.Control.DeepSeq

--- a/library/Control/Exception.hs
+++ b/library/Control/Exception.hs
@@ -1,7 +1,0 @@
-module Control.Exception
-(
-  module Rebase.Control.Exception
-)
-where
-
-import Rebase.Control.Exception

--- a/library/Control/Exception/Base.hs
+++ b/library/Control/Exception/Base.hs
@@ -1,7 +1,0 @@
-module Control.Exception.Base
-(
-  module Rebase.Control.Exception.Base
-)
-where
-
-import Rebase.Control.Exception.Base

--- a/library/Control/Monad.hs
+++ b/library/Control/Monad.hs
@@ -1,7 +1,0 @@
-module Control.Monad
-(
-  module Rebase.Control.Monad
-)
-where
-
-import Rebase.Control.Monad

--- a/library/Control/Monad/Cont.hs
+++ b/library/Control/Monad/Cont.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Cont
-(
-  module Rebase.Control.Monad.Cont
-)
-where
-
-import Rebase.Control.Monad.Cont

--- a/library/Control/Monad/Cont/Class.hs
+++ b/library/Control/Monad/Cont/Class.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Cont.Class
-(
-  module Rebase.Control.Monad.Cont.Class
-)
-where
-
-import Rebase.Control.Monad.Cont.Class

--- a/library/Control/Monad/Error/Class.hs
+++ b/library/Control/Monad/Error/Class.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Error.Class
-(
-  module Rebase.Control.Monad.Error.Class
-)
-where
-
-import Rebase.Control.Monad.Error.Class

--- a/library/Control/Monad/Fail.hs
+++ b/library/Control/Monad/Fail.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Fail
-(
-  module Rebase.Control.Monad.Fail
-)
-where
-
-import Rebase.Control.Monad.Fail

--- a/library/Control/Monad/Fix.hs
+++ b/library/Control/Monad/Fix.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Fix
-(
-  module Rebase.Control.Monad.Fix
-)
-where
-
-import Rebase.Control.Monad.Fix

--- a/library/Control/Monad/IO/Class.hs
+++ b/library/Control/Monad/IO/Class.hs
@@ -1,7 +1,0 @@
-module Control.Monad.IO.Class
-(
-  module Rebase.Control.Monad.IO.Class
-)
-where
-
-import Rebase.Control.Monad.IO.Class

--- a/library/Control/Monad/Identity.hs
+++ b/library/Control/Monad/Identity.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Identity
-(
-  module Rebase.Control.Monad.Identity
-)
-where
-
-import Rebase.Control.Monad.Identity

--- a/library/Control/Monad/RWS.hs
+++ b/library/Control/Monad/RWS.hs
@@ -1,7 +1,0 @@
-module Control.Monad.RWS
-(
-  module Rebase.Control.Monad.RWS
-)
-where
-
-import Rebase.Control.Monad.RWS

--- a/library/Control/Monad/RWS/Class.hs
+++ b/library/Control/Monad/RWS/Class.hs
@@ -1,7 +1,0 @@
-module Control.Monad.RWS.Class
-(
-  module Rebase.Control.Monad.RWS.Class
-)
-where
-
-import Rebase.Control.Monad.RWS.Class

--- a/library/Control/Monad/RWS/Lazy.hs
+++ b/library/Control/Monad/RWS/Lazy.hs
@@ -1,7 +1,0 @@
-module Control.Monad.RWS.Lazy
-(
-  module Rebase.Control.Monad.RWS.Lazy
-)
-where
-
-import Rebase.Control.Monad.RWS.Lazy

--- a/library/Control/Monad/RWS/Strict.hs
+++ b/library/Control/Monad/RWS/Strict.hs
@@ -1,7 +1,0 @@
-module Control.Monad.RWS.Strict
-(
-  module Rebase.Control.Monad.RWS.Strict
-)
-where
-
-import Rebase.Control.Monad.RWS.Strict

--- a/library/Control/Monad/Reader.hs
+++ b/library/Control/Monad/Reader.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Reader
-(
-  module Rebase.Control.Monad.Reader
-)
-where
-
-import Rebase.Control.Monad.Reader

--- a/library/Control/Monad/Reader/Class.hs
+++ b/library/Control/Monad/Reader/Class.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Reader.Class
-(
-  module Rebase.Control.Monad.Reader.Class
-)
-where
-
-import Rebase.Control.Monad.Reader.Class

--- a/library/Control/Monad/ST.hs
+++ b/library/Control/Monad/ST.hs
@@ -1,7 +1,0 @@
-module Control.Monad.ST
-(
-  module Rebase.Control.Monad.ST
-)
-where
-
-import Rebase.Control.Monad.ST

--- a/library/Control/Monad/ST/Lazy.hs
+++ b/library/Control/Monad/ST/Lazy.hs
@@ -1,7 +1,0 @@
-module Control.Monad.ST.Lazy
-(
-  module Rebase.Control.Monad.ST.Lazy
-)
-where
-
-import Rebase.Control.Monad.ST.Lazy

--- a/library/Control/Monad/ST/Lazy/Unsafe.hs
+++ b/library/Control/Monad/ST/Lazy/Unsafe.hs
@@ -1,7 +1,0 @@
-module Control.Monad.ST.Lazy.Unsafe
-(
-  module Rebase.Control.Monad.ST.Lazy.Unsafe
-)
-where
-
-import Rebase.Control.Monad.ST.Lazy.Unsafe

--- a/library/Control/Monad/ST/Strict.hs
+++ b/library/Control/Monad/ST/Strict.hs
@@ -1,7 +1,0 @@
-module Control.Monad.ST.Strict
-(
-  module Rebase.Control.Monad.ST.Strict
-)
-where
-
-import Rebase.Control.Monad.ST.Strict

--- a/library/Control/Monad/ST/Unsafe.hs
+++ b/library/Control/Monad/ST/Unsafe.hs
@@ -1,7 +1,0 @@
-module Control.Monad.ST.Unsafe
-(
-  module Rebase.Control.Monad.ST.Unsafe
-)
-where
-
-import Rebase.Control.Monad.ST.Unsafe

--- a/library/Control/Monad/STM.hs
+++ b/library/Control/Monad/STM.hs
@@ -1,7 +1,0 @@
-module Control.Monad.STM
-(
-  module Rebase.Control.Monad.STM
-)
-where
-
-import Rebase.Control.Monad.STM

--- a/library/Control/Monad/Signatures.hs
+++ b/library/Control/Monad/Signatures.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Signatures
-(
-  module Rebase.Control.Monad.Signatures
-)
-where
-
-import Rebase.Control.Monad.Signatures

--- a/library/Control/Monad/State.hs
+++ b/library/Control/Monad/State.hs
@@ -1,7 +1,0 @@
-module Control.Monad.State
-(
-  module Rebase.Control.Monad.State
-)
-where
-
-import Rebase.Control.Monad.State

--- a/library/Control/Monad/State/Class.hs
+++ b/library/Control/Monad/State/Class.hs
@@ -1,7 +1,0 @@
-module Control.Monad.State.Class
-(
-  module Rebase.Control.Monad.State.Class
-)
-where
-
-import Rebase.Control.Monad.State.Class

--- a/library/Control/Monad/State/Lazy.hs
+++ b/library/Control/Monad/State/Lazy.hs
@@ -1,7 +1,0 @@
-module Control.Monad.State.Lazy
-(
-  module Rebase.Control.Monad.State.Lazy
-)
-where
-
-import Rebase.Control.Monad.State.Lazy

--- a/library/Control/Monad/State/Strict.hs
+++ b/library/Control/Monad/State/Strict.hs
@@ -1,7 +1,0 @@
-module Control.Monad.State.Strict
-(
-  module Rebase.Control.Monad.State.Strict
-)
-where
-
-import Rebase.Control.Monad.State.Strict

--- a/library/Control/Monad/Trans.hs
+++ b/library/Control/Monad/Trans.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans
-(
-  module Rebase.Control.Monad.Trans
-)
-where
-
-import Rebase.Control.Monad.Trans

--- a/library/Control/Monad/Trans/Class.hs
+++ b/library/Control/Monad/Trans/Class.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.Class
-(
-  module Rebase.Control.Monad.Trans.Class
-)
-where
-
-import Rebase.Control.Monad.Trans.Class

--- a/library/Control/Monad/Trans/Cont.hs
+++ b/library/Control/Monad/Trans/Cont.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.Cont
-(
-  module Rebase.Control.Monad.Trans.Cont
-)
-where
-
-import Rebase.Control.Monad.Trans.Cont

--- a/library/Control/Monad/Trans/Except.hs
+++ b/library/Control/Monad/Trans/Except.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.Except
-(
-  module Rebase.Control.Monad.Trans.Except
-)
-where
-
-import Rebase.Control.Monad.Trans.Except

--- a/library/Control/Monad/Trans/Identity.hs
+++ b/library/Control/Monad/Trans/Identity.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.Identity
-(
-  module Rebase.Control.Monad.Trans.Identity
-)
-where
-
-import Rebase.Control.Monad.Trans.Identity

--- a/library/Control/Monad/Trans/Maybe.hs
+++ b/library/Control/Monad/Trans/Maybe.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.Maybe
-(
-  module Rebase.Control.Monad.Trans.Maybe
-)
-where
-
-import Rebase.Control.Monad.Trans.Maybe

--- a/library/Control/Monad/Trans/RWS.hs
+++ b/library/Control/Monad/Trans/RWS.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.RWS
-(
-  module Rebase.Control.Monad.Trans.RWS
-)
-where
-
-import Rebase.Control.Monad.Trans.RWS

--- a/library/Control/Monad/Trans/RWS/Lazy.hs
+++ b/library/Control/Monad/Trans/RWS/Lazy.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.RWS.Lazy
-(
-  module Rebase.Control.Monad.Trans.RWS.Lazy
-)
-where
-
-import Rebase.Control.Monad.Trans.RWS.Lazy

--- a/library/Control/Monad/Trans/RWS/Strict.hs
+++ b/library/Control/Monad/Trans/RWS/Strict.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.RWS.Strict
-(
-  module Rebase.Control.Monad.Trans.RWS.Strict
-)
-where
-
-import Rebase.Control.Monad.Trans.RWS.Strict

--- a/library/Control/Monad/Trans/Reader.hs
+++ b/library/Control/Monad/Trans/Reader.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.Reader
-(
-  module Rebase.Control.Monad.Trans.Reader
-)
-where
-
-import Rebase.Control.Monad.Trans.Reader

--- a/library/Control/Monad/Trans/State.hs
+++ b/library/Control/Monad/Trans/State.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.State
-(
-  module Rebase.Control.Monad.Trans.State
-)
-where
-
-import Rebase.Control.Monad.Trans.State

--- a/library/Control/Monad/Trans/State/Lazy.hs
+++ b/library/Control/Monad/Trans/State/Lazy.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.State.Lazy
-(
-  module Rebase.Control.Monad.Trans.State.Lazy
-)
-where
-
-import Rebase.Control.Monad.Trans.State.Lazy

--- a/library/Control/Monad/Trans/State/Strict.hs
+++ b/library/Control/Monad/Trans/State/Strict.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.State.Strict
-(
-  module Rebase.Control.Monad.Trans.State.Strict
-)
-where
-
-import Rebase.Control.Monad.Trans.State.Strict

--- a/library/Control/Monad/Trans/Writer.hs
+++ b/library/Control/Monad/Trans/Writer.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.Writer
-(
-  module Rebase.Control.Monad.Trans.Writer
-)
-where
-
-import Rebase.Control.Monad.Trans.Writer

--- a/library/Control/Monad/Trans/Writer/Lazy.hs
+++ b/library/Control/Monad/Trans/Writer/Lazy.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.Writer.Lazy
-(
-  module Rebase.Control.Monad.Trans.Writer.Lazy
-)
-where
-
-import Rebase.Control.Monad.Trans.Writer.Lazy

--- a/library/Control/Monad/Trans/Writer/Strict.hs
+++ b/library/Control/Monad/Trans/Writer/Strict.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Trans.Writer.Strict
-(
-  module Rebase.Control.Monad.Trans.Writer.Strict
-)
-where
-
-import Rebase.Control.Monad.Trans.Writer.Strict

--- a/library/Control/Monad/Writer.hs
+++ b/library/Control/Monad/Writer.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Writer
-(
-  module Rebase.Control.Monad.Writer
-)
-where
-
-import Rebase.Control.Monad.Writer

--- a/library/Control/Monad/Writer/Class.hs
+++ b/library/Control/Monad/Writer/Class.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Writer.Class
-(
-  module Rebase.Control.Monad.Writer.Class
-)
-where
-
-import Rebase.Control.Monad.Writer.Class

--- a/library/Control/Monad/Writer/Lazy.hs
+++ b/library/Control/Monad/Writer/Lazy.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Writer.Lazy
-(
-  module Rebase.Control.Monad.Writer.Lazy
-)
-where
-
-import Rebase.Control.Monad.Writer.Lazy

--- a/library/Control/Monad/Writer/Strict.hs
+++ b/library/Control/Monad/Writer/Strict.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Writer.Strict
-(
-  module Rebase.Control.Monad.Writer.Strict
-)
-where
-
-import Rebase.Control.Monad.Writer.Strict

--- a/library/Control/Monad/Zip.hs
+++ b/library/Control/Monad/Zip.hs
@@ -1,7 +1,0 @@
-module Control.Monad.Zip
-(
-  module Rebase.Control.Monad.Zip
-)
-where
-
-import Rebase.Control.Monad.Zip

--- a/library/Control/Selective.hs
+++ b/library/Control/Selective.hs
@@ -1,7 +1,0 @@
-module Control.Selective
-(
-  module Rebase.Control.Selective
-)
-where
-
-import Rebase.Control.Selective

--- a/library/Control/Selective/Free.hs
+++ b/library/Control/Selective/Free.hs
@@ -1,7 +1,0 @@
-module Control.Selective.Free
-(
-  module Rebase.Control.Selective.Free
-)
-where
-
-import Rebase.Control.Selective.Free

--- a/library/Control/Selective/Multi.hs
+++ b/library/Control/Selective/Multi.hs
@@ -1,7 +1,0 @@
-module Control.Selective.Multi
-(
-  module Rebase.Control.Selective.Multi
-)
-where
-
-import Rebase.Control.Selective.Multi

--- a/library/Control/Selective/Rigid/Free.hs
+++ b/library/Control/Selective/Rigid/Free.hs
@@ -1,7 +1,0 @@
-module Control.Selective.Rigid.Free
-(
-  module Rebase.Control.Selective.Rigid.Free
-)
-where
-
-import Rebase.Control.Selective.Rigid.Free

--- a/library/Control/Selective/Rigid/Freer.hs
+++ b/library/Control/Selective/Rigid/Freer.hs
@@ -1,7 +1,0 @@
-module Control.Selective.Rigid.Freer
-(
-  module Rebase.Control.Selective.Rigid.Freer
-)
-where
-
-import Rebase.Control.Selective.Rigid.Freer

--- a/library/Data/Biapplicative.hs
+++ b/library/Data/Biapplicative.hs
@@ -1,7 +1,0 @@
-module Data.Biapplicative
-(
-  module Rebase.Data.Biapplicative
-)
-where
-
-import Rebase.Data.Biapplicative

--- a/library/Data/Bifoldable.hs
+++ b/library/Data/Bifoldable.hs
@@ -1,7 +1,0 @@
-module Data.Bifoldable
-(
-  module Rebase.Data.Bifoldable
-)
-where
-
-import Rebase.Data.Bifoldable

--- a/library/Data/Bifunctor.hs
+++ b/library/Data/Bifunctor.hs
@@ -1,7 +1,0 @@
-module Data.Bifunctor
-(
-  module Rebase.Data.Bifunctor
-)
-where
-
-import Rebase.Data.Bifunctor

--- a/library/Data/Bifunctor/Apply.hs
+++ b/library/Data/Bifunctor/Apply.hs
@@ -1,7 +1,0 @@
-module Data.Bifunctor.Apply
-(
-  module Rebase.Data.Bifunctor.Apply
-)
-where
-
-import Rebase.Data.Bifunctor.Apply

--- a/library/Data/Bifunctor/Biff.hs
+++ b/library/Data/Bifunctor/Biff.hs
@@ -1,7 +1,0 @@
-module Data.Bifunctor.Biff
-(
-  module Rebase.Data.Bifunctor.Biff
-)
-where
-
-import Rebase.Data.Bifunctor.Biff

--- a/library/Data/Bifunctor/Clown.hs
+++ b/library/Data/Bifunctor/Clown.hs
@@ -1,7 +1,0 @@
-module Data.Bifunctor.Clown
-(
-  module Rebase.Data.Bifunctor.Clown
-)
-where
-
-import Rebase.Data.Bifunctor.Clown

--- a/library/Data/Bifunctor/Flip.hs
+++ b/library/Data/Bifunctor/Flip.hs
@@ -1,7 +1,0 @@
-module Data.Bifunctor.Flip
-(
-  module Rebase.Data.Bifunctor.Flip
-)
-where
-
-import Rebase.Data.Bifunctor.Flip

--- a/library/Data/Bifunctor/Join.hs
+++ b/library/Data/Bifunctor/Join.hs
@@ -1,7 +1,0 @@
-module Data.Bifunctor.Join
-(
-  module Rebase.Data.Bifunctor.Join
-)
-where
-
-import Rebase.Data.Bifunctor.Join

--- a/library/Data/Bifunctor/Joker.hs
+++ b/library/Data/Bifunctor/Joker.hs
@@ -1,7 +1,0 @@
-module Data.Bifunctor.Joker
-(
-  module Rebase.Data.Bifunctor.Joker
-)
-where
-
-import Rebase.Data.Bifunctor.Joker

--- a/library/Data/Bifunctor/Product.hs
+++ b/library/Data/Bifunctor/Product.hs
@@ -1,7 +1,0 @@
-module Data.Bifunctor.Product
-(
-  module Rebase.Data.Bifunctor.Product
-)
-where
-
-import Rebase.Data.Bifunctor.Product

--- a/library/Data/Bifunctor/Tannen.hs
+++ b/library/Data/Bifunctor/Tannen.hs
@@ -1,7 +1,0 @@
-module Data.Bifunctor.Tannen
-(
-  module Rebase.Data.Bifunctor.Tannen
-)
-where
-
-import Rebase.Data.Bifunctor.Tannen

--- a/library/Data/Bifunctor/Wrapped.hs
+++ b/library/Data/Bifunctor/Wrapped.hs
@@ -1,7 +1,0 @@
-module Data.Bifunctor.Wrapped
-(
-  module Rebase.Data.Bifunctor.Wrapped
-)
-where
-
-import Rebase.Data.Bifunctor.Wrapped

--- a/library/Data/Bitraversable.hs
+++ b/library/Data/Bitraversable.hs
@@ -1,7 +1,0 @@
-module Data.Bitraversable
-(
-  module Rebase.Data.Bitraversable
-)
-where
-
-import Rebase.Data.Bitraversable

--- a/library/Data/Bits.hs
+++ b/library/Data/Bits.hs
@@ -1,7 +1,0 @@
-module Data.Bits
-(
-  module Rebase.Data.Bits
-)
-where
-
-import Rebase.Data.Bits

--- a/library/Data/Bool.hs
+++ b/library/Data/Bool.hs
@@ -1,7 +1,0 @@
-module Data.Bool
-(
-  module Rebase.Data.Bool
-)
-where
-
-import Rebase.Data.Bool

--- a/library/Data/ByteString.hs
+++ b/library/Data/ByteString.hs
@@ -1,7 +1,0 @@
-module Data.ByteString
-(
-  module Rebase.Data.ByteString
-)
-where
-
-import Rebase.Data.ByteString

--- a/library/Data/ByteString/Builder.hs
+++ b/library/Data/ByteString/Builder.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Builder
-(
-  module Rebase.Data.ByteString.Builder
-)
-where
-
-import Rebase.Data.ByteString.Builder

--- a/library/Data/ByteString/Builder/Extra.hs
+++ b/library/Data/ByteString/Builder/Extra.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Builder.Extra
-(
-  module Rebase.Data.ByteString.Builder.Extra
-)
-where
-
-import Rebase.Data.ByteString.Builder.Extra

--- a/library/Data/ByteString/Builder/Internal.hs
+++ b/library/Data/ByteString/Builder/Internal.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Builder.Internal
-(
-  module Rebase.Data.ByteString.Builder.Internal
-)
-where
-
-import Rebase.Data.ByteString.Builder.Internal

--- a/library/Data/ByteString/Builder/Prim.hs
+++ b/library/Data/ByteString/Builder/Prim.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Builder.Prim
-(
-  module Rebase.Data.ByteString.Builder.Prim
-)
-where
-
-import Rebase.Data.ByteString.Builder.Prim

--- a/library/Data/ByteString/Builder/Prim/Internal.hs
+++ b/library/Data/ByteString/Builder/Prim/Internal.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Builder.Prim.Internal
-(
-  module Rebase.Data.ByteString.Builder.Prim.Internal
-)
-where
-
-import Rebase.Data.ByteString.Builder.Prim.Internal

--- a/library/Data/ByteString/Builder/Scientific.hs
+++ b/library/Data/ByteString/Builder/Scientific.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Builder.Scientific
-(
-  module Rebase.Data.ByteString.Builder.Scientific
-)
-where
-
-import Rebase.Data.ByteString.Builder.Scientific

--- a/library/Data/ByteString/Char8.hs
+++ b/library/Data/ByteString/Char8.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Char8
-(
-  module Rebase.Data.ByteString.Char8
-)
-where
-
-import Rebase.Data.ByteString.Char8

--- a/library/Data/ByteString/Internal.hs
+++ b/library/Data/ByteString/Internal.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Internal
-(
-  module Rebase.Data.ByteString.Internal
-)
-where
-
-import Rebase.Data.ByteString.Internal

--- a/library/Data/ByteString/Lazy.hs
+++ b/library/Data/ByteString/Lazy.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Lazy
-(
-  module Rebase.Data.ByteString.Lazy
-)
-where
-
-import Rebase.Data.ByteString.Lazy

--- a/library/Data/ByteString/Lazy/Char8.hs
+++ b/library/Data/ByteString/Lazy/Char8.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Lazy.Char8
-(
-  module Rebase.Data.ByteString.Lazy.Char8
-)
-where
-
-import Rebase.Data.ByteString.Lazy.Char8

--- a/library/Data/ByteString/Lazy/Internal.hs
+++ b/library/Data/ByteString/Lazy/Internal.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Lazy.Internal
-(
-  module Rebase.Data.ByteString.Lazy.Internal
-)
-where
-
-import Rebase.Data.ByteString.Lazy.Internal

--- a/library/Data/ByteString/Short.hs
+++ b/library/Data/ByteString/Short.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Short
-(
-  module Rebase.Data.ByteString.Short
-)
-where
-
-import Rebase.Data.ByteString.Short

--- a/library/Data/ByteString/Short/Internal.hs
+++ b/library/Data/ByteString/Short/Internal.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Short.Internal
-(
-  module Rebase.Data.ByteString.Short.Internal
-)
-where
-
-import Rebase.Data.ByteString.Short.Internal

--- a/library/Data/ByteString/Unsafe.hs
+++ b/library/Data/ByteString/Unsafe.hs
@@ -1,7 +1,0 @@
-module Data.ByteString.Unsafe
-(
-  module Rebase.Data.ByteString.Unsafe
-)
-where
-
-import Rebase.Data.ByteString.Unsafe

--- a/library/Data/Char.hs
+++ b/library/Data/Char.hs
@@ -1,7 +1,0 @@
-module Data.Char
-(
-  module Rebase.Data.Char
-)
-where
-
-import Rebase.Data.Char

--- a/library/Data/Coerce.hs
+++ b/library/Data/Coerce.hs
@@ -1,7 +1,0 @@
-module Data.Coerce
-(
-  module Rebase.Data.Coerce
-)
-where
-
-import Rebase.Data.Coerce

--- a/library/Data/Complex.hs
+++ b/library/Data/Complex.hs
@@ -1,7 +1,0 @@
-module Data.Complex
-(
-  module Rebase.Data.Complex
-)
-where
-
-import Rebase.Data.Complex

--- a/library/Data/DList.hs
+++ b/library/Data/DList.hs
@@ -1,7 +1,0 @@
-module Data.DList
-(
-  module Rebase.Data.DList
-)
-where
-
-import Rebase.Data.DList

--- a/library/Data/Data.hs
+++ b/library/Data/Data.hs
@@ -1,7 +1,0 @@
-module Data.Data
-(
-  module Rebase.Data.Data
-)
-where
-
-import Rebase.Data.Data

--- a/library/Data/Dynamic.hs
+++ b/library/Data/Dynamic.hs
@@ -1,7 +1,0 @@
-module Data.Dynamic
-(
-  module Rebase.Data.Dynamic
-)
-where
-
-import Rebase.Data.Dynamic

--- a/library/Data/Either.hs
+++ b/library/Data/Either.hs
@@ -1,7 +1,0 @@
-module Data.Either
-(
-  module Rebase.Data.Either
-)
-where
-
-import Rebase.Data.Either

--- a/library/Data/Either/Combinators.hs
+++ b/library/Data/Either/Combinators.hs
@@ -1,7 +1,0 @@
-module Data.Either.Combinators
-(
-  module Rebase.Data.Either.Combinators
-)
-where
-
-import Rebase.Data.Either.Combinators

--- a/library/Data/Either/Validation.hs
+++ b/library/Data/Either/Validation.hs
@@ -1,7 +1,0 @@
-module Data.Either.Validation
-(
-  module Rebase.Data.Either.Validation
-)
-where
-
-import Rebase.Data.Either.Validation

--- a/library/Data/Eq.hs
+++ b/library/Data/Eq.hs
@@ -1,7 +1,0 @@
-module Data.Eq
-(
-  module Rebase.Data.Eq
-)
-where
-
-import Rebase.Data.Eq

--- a/library/Data/Fixed.hs
+++ b/library/Data/Fixed.hs
@@ -1,7 +1,0 @@
-module Data.Fixed
-(
-  module Rebase.Data.Fixed
-)
-where
-
-import Rebase.Data.Fixed

--- a/library/Data/Foldable.hs
+++ b/library/Data/Foldable.hs
@@ -1,7 +1,0 @@
-module Data.Foldable
-(
-  module Rebase.Data.Foldable
-)
-where
-
-import Rebase.Data.Foldable

--- a/library/Data/Function.hs
+++ b/library/Data/Function.hs
@@ -1,7 +1,0 @@
-module Data.Function
-(
-  module Rebase.Data.Function
-)
-where
-
-import Rebase.Data.Function

--- a/library/Data/Functor.hs
+++ b/library/Data/Functor.hs
@@ -1,7 +1,0 @@
-module Data.Functor
-(
-  module Rebase.Data.Functor
-)
-where
-
-import Rebase.Data.Functor

--- a/library/Data/Functor/Alt.hs
+++ b/library/Data/Functor/Alt.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Alt
-(
-  module Rebase.Data.Functor.Alt
-)
-where
-
-import Rebase.Data.Functor.Alt

--- a/library/Data/Functor/Apply.hs
+++ b/library/Data/Functor/Apply.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Apply
-(
-  module Rebase.Data.Functor.Apply
-)
-where
-
-import Rebase.Data.Functor.Apply

--- a/library/Data/Functor/Bind.hs
+++ b/library/Data/Functor/Bind.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Bind
-(
-  module Rebase.Data.Functor.Bind
-)
-where
-
-import Rebase.Data.Functor.Bind

--- a/library/Data/Functor/Bind/Class.hs
+++ b/library/Data/Functor/Bind/Class.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Bind.Class
-(
-  module Rebase.Data.Functor.Bind.Class
-)
-where
-
-import Rebase.Data.Functor.Bind.Class

--- a/library/Data/Functor/Bind/Trans.hs
+++ b/library/Data/Functor/Bind/Trans.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Bind.Trans
-(
-  module Rebase.Data.Functor.Bind.Trans
-)
-where
-
-import Rebase.Data.Functor.Bind.Trans

--- a/library/Data/Functor/Classes.hs
+++ b/library/Data/Functor/Classes.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Classes
-(
-  module Rebase.Data.Functor.Classes
-)
-where
-
-import Rebase.Data.Functor.Classes

--- a/library/Data/Functor/Compose.hs
+++ b/library/Data/Functor/Compose.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Compose
-(
-  module Rebase.Data.Functor.Compose
-)
-where
-
-import Rebase.Data.Functor.Compose

--- a/library/Data/Functor/Constant.hs
+++ b/library/Data/Functor/Constant.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Constant
-(
-  module Rebase.Data.Functor.Constant
-)
-where
-
-import Rebase.Data.Functor.Constant

--- a/library/Data/Functor/Contravariant.hs
+++ b/library/Data/Functor/Contravariant.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Contravariant
-(
-  module Rebase.Data.Functor.Contravariant
-)
-where
-
-import Rebase.Data.Functor.Contravariant

--- a/library/Data/Functor/Contravariant/Compose.hs
+++ b/library/Data/Functor/Contravariant/Compose.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Contravariant.Compose
-(
-  module Rebase.Data.Functor.Contravariant.Compose
-)
-where
-
-import Rebase.Data.Functor.Contravariant.Compose

--- a/library/Data/Functor/Contravariant/Divisible.hs
+++ b/library/Data/Functor/Contravariant/Divisible.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Contravariant.Divisible
-(
-  module Rebase.Data.Functor.Contravariant.Divisible
-)
-where
-
-import Rebase.Data.Functor.Contravariant.Divisible

--- a/library/Data/Functor/Extend.hs
+++ b/library/Data/Functor/Extend.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Extend
-(
-  module Rebase.Data.Functor.Extend
-)
-where
-
-import Rebase.Data.Functor.Extend

--- a/library/Data/Functor/Identity.hs
+++ b/library/Data/Functor/Identity.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Identity
-(
-  module Rebase.Data.Functor.Identity
-)
-where
-
-import Rebase.Data.Functor.Identity

--- a/library/Data/Functor/Invariant.hs
+++ b/library/Data/Functor/Invariant.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Invariant
-(
-  module Rebase.Data.Functor.Invariant
-)
-where
-
-import Rebase.Data.Functor.Invariant

--- a/library/Data/Functor/Invariant/TH.hs
+++ b/library/Data/Functor/Invariant/TH.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Invariant.TH
-(
-  module Rebase.Data.Functor.Invariant.TH
-)
-where
-
-import Rebase.Data.Functor.Invariant.TH

--- a/library/Data/Functor/Plus.hs
+++ b/library/Data/Functor/Plus.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Plus
-(
-  module Rebase.Data.Functor.Plus
-)
-where
-
-import Rebase.Data.Functor.Plus

--- a/library/Data/Functor/Product.hs
+++ b/library/Data/Functor/Product.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Product
-(
-  module Rebase.Data.Functor.Product
-)
-where
-
-import Rebase.Data.Functor.Product

--- a/library/Data/Functor/Reverse.hs
+++ b/library/Data/Functor/Reverse.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Reverse
-(
-  module Rebase.Data.Functor.Reverse
-)
-where
-
-import Rebase.Data.Functor.Reverse

--- a/library/Data/Functor/Sum.hs
+++ b/library/Data/Functor/Sum.hs
@@ -1,7 +1,0 @@
-module Data.Functor.Sum
-(
-  module Rebase.Data.Functor.Sum
-)
-where
-
-import Rebase.Data.Functor.Sum

--- a/library/Data/Graph.hs
+++ b/library/Data/Graph.hs
@@ -1,7 +1,0 @@
-module Data.Graph
-(
-  module Rebase.Data.Graph
-)
-where
-
-import Rebase.Data.Graph

--- a/library/Data/Group.hs
+++ b/library/Data/Group.hs
@@ -1,7 +1,0 @@
-module Data.Group
-(
-  module Rebase.Data.Group
-)
-where
-
-import Rebase.Data.Group

--- a/library/Data/Groupoid.hs
+++ b/library/Data/Groupoid.hs
@@ -1,7 +1,0 @@
-module Data.Groupoid
-(
-  module Rebase.Data.Groupoid
-)
-where
-
-import Rebase.Data.Groupoid

--- a/library/Data/HashMap/Lazy.hs
+++ b/library/Data/HashMap/Lazy.hs
@@ -1,7 +1,0 @@
-module Data.HashMap.Lazy
-(
-  module Rebase.Data.HashMap.Lazy
-)
-where
-
-import Rebase.Data.HashMap.Lazy

--- a/library/Data/HashMap/Strict.hs
+++ b/library/Data/HashMap/Strict.hs
@@ -1,7 +1,0 @@
-module Data.HashMap.Strict
-(
-  module Rebase.Data.HashMap.Strict
-)
-where
-
-import Rebase.Data.HashMap.Strict

--- a/library/Data/HashSet.hs
+++ b/library/Data/HashSet.hs
@@ -1,7 +1,0 @@
-module Data.HashSet
-(
-  module Rebase.Data.HashSet
-)
-where
-
-import Rebase.Data.HashSet

--- a/library/Data/Hashable.hs
+++ b/library/Data/Hashable.hs
@@ -1,7 +1,0 @@
-module Data.Hashable
-(
-  module Rebase.Data.Hashable
-)
-where
-
-import Rebase.Data.Hashable

--- a/library/Data/IORef.hs
+++ b/library/Data/IORef.hs
@@ -1,7 +1,0 @@
-module Data.IORef
-(
-  module Rebase.Data.IORef
-)
-where
-
-import Rebase.Data.IORef

--- a/library/Data/Int.hs
+++ b/library/Data/Int.hs
@@ -1,7 +1,0 @@
-module Data.Int
-(
-  module Rebase.Data.Int
-)
-where
-
-import Rebase.Data.Int

--- a/library/Data/IntMap.hs
+++ b/library/Data/IntMap.hs
@@ -1,7 +1,0 @@
-module Data.IntMap
-(
-  module Rebase.Data.IntMap
-)
-where
-
-import Rebase.Data.IntMap

--- a/library/Data/IntMap/Lazy.hs
+++ b/library/Data/IntMap/Lazy.hs
@@ -1,7 +1,0 @@
-module Data.IntMap.Lazy
-(
-  module Rebase.Data.IntMap.Lazy
-)
-where
-
-import Rebase.Data.IntMap.Lazy

--- a/library/Data/IntMap/Strict.hs
+++ b/library/Data/IntMap/Strict.hs
@@ -1,7 +1,0 @@
-module Data.IntMap.Strict
-(
-  module Rebase.Data.IntMap.Strict
-)
-where
-
-import Rebase.Data.IntMap.Strict

--- a/library/Data/IntSet.hs
+++ b/library/Data/IntSet.hs
@@ -1,7 +1,0 @@
-module Data.IntSet
-(
-  module Rebase.Data.IntSet
-)
-where
-
-import Rebase.Data.IntSet

--- a/library/Data/Isomorphism.hs
+++ b/library/Data/Isomorphism.hs
@@ -1,7 +1,0 @@
-module Data.Isomorphism
-(
-  module Rebase.Data.Isomorphism
-)
-where
-
-import Rebase.Data.Isomorphism

--- a/library/Data/Ix.hs
+++ b/library/Data/Ix.hs
@@ -1,7 +1,0 @@
-module Data.Ix
-(
-  module Rebase.Data.Ix
-)
-where
-
-import Rebase.Data.Ix

--- a/library/Data/Kind.hs
+++ b/library/Data/Kind.hs
@@ -1,7 +1,0 @@
-module Data.Kind
-(
-  module Rebase.Data.Kind
-)
-where
-
-import Rebase.Data.Kind

--- a/library/Data/List.hs
+++ b/library/Data/List.hs
@@ -1,7 +1,0 @@
-module Data.List
-(
-  module Rebase.Data.List
-)
-where
-
-import Rebase.Data.List

--- a/library/Data/List/NonEmpty.hs
+++ b/library/Data/List/NonEmpty.hs
@@ -1,7 +1,0 @@
-module Data.List.NonEmpty
-(
-  module Rebase.Data.List.NonEmpty
-)
-where
-
-import Rebase.Data.List.NonEmpty

--- a/library/Data/Map.hs
+++ b/library/Data/Map.hs
@@ -1,7 +1,0 @@
-module Data.Map
-(
-  module Rebase.Data.Map
-)
-where
-
-import Rebase.Data.Map

--- a/library/Data/Map/Lazy.hs
+++ b/library/Data/Map/Lazy.hs
@@ -1,7 +1,0 @@
-module Data.Map.Lazy
-(
-  module Rebase.Data.Map.Lazy
-)
-where
-
-import Rebase.Data.Map.Lazy

--- a/library/Data/Map/Strict.hs
+++ b/library/Data/Map/Strict.hs
@@ -1,7 +1,0 @@
-module Data.Map.Strict
-(
-  module Rebase.Data.Map.Strict
-)
-where
-
-import Rebase.Data.Map.Strict

--- a/library/Data/Maybe.hs
+++ b/library/Data/Maybe.hs
@@ -1,7 +1,0 @@
-module Data.Maybe
-(
-  module Rebase.Data.Maybe
-)
-where
-
-import Rebase.Data.Maybe

--- a/library/Data/Monoid.hs
+++ b/library/Data/Monoid.hs
@@ -1,7 +1,0 @@
-module Data.Monoid
-(
-  module Rebase.Data.Monoid
-)
-where
-
-import Rebase.Data.Monoid

--- a/library/Data/Ord.hs
+++ b/library/Data/Ord.hs
@@ -1,7 +1,0 @@
-module Data.Ord
-(
-  module Rebase.Data.Ord
-)
-where
-
-import Rebase.Data.Ord

--- a/library/Data/Profunctor.hs
+++ b/library/Data/Profunctor.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor
-(
-  module Rebase.Data.Profunctor
-)
-where
-
-import Rebase.Data.Profunctor

--- a/library/Data/Profunctor/Adjunction.hs
+++ b/library/Data/Profunctor/Adjunction.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Adjunction
-(
-  module Rebase.Data.Profunctor.Adjunction
-)
-where
-
-import Rebase.Data.Profunctor.Adjunction

--- a/library/Data/Profunctor/Cayley.hs
+++ b/library/Data/Profunctor/Cayley.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Cayley
-(
-  module Rebase.Data.Profunctor.Cayley
-)
-where
-
-import Rebase.Data.Profunctor.Cayley

--- a/library/Data/Profunctor/Choice.hs
+++ b/library/Data/Profunctor/Choice.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Choice
-(
-  module Rebase.Data.Profunctor.Choice
-)
-where
-
-import Rebase.Data.Profunctor.Choice

--- a/library/Data/Profunctor/Closed.hs
+++ b/library/Data/Profunctor/Closed.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Closed
-(
-  module Rebase.Data.Profunctor.Closed
-)
-where
-
-import Rebase.Data.Profunctor.Closed

--- a/library/Data/Profunctor/Composition.hs
+++ b/library/Data/Profunctor/Composition.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Composition
-(
-  module Rebase.Data.Profunctor.Composition
-)
-where
-
-import Rebase.Data.Profunctor.Composition

--- a/library/Data/Profunctor/Mapping.hs
+++ b/library/Data/Profunctor/Mapping.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Mapping
-(
-  module Rebase.Data.Profunctor.Mapping
-)
-where
-
-import Rebase.Data.Profunctor.Mapping

--- a/library/Data/Profunctor/Monad.hs
+++ b/library/Data/Profunctor/Monad.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Monad
-(
-  module Rebase.Data.Profunctor.Monad
-)
-where
-
-import Rebase.Data.Profunctor.Monad

--- a/library/Data/Profunctor/Ran.hs
+++ b/library/Data/Profunctor/Ran.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Ran
-(
-  module Rebase.Data.Profunctor.Ran
-)
-where
-
-import Rebase.Data.Profunctor.Ran

--- a/library/Data/Profunctor/Rep.hs
+++ b/library/Data/Profunctor/Rep.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Rep
-(
-  module Rebase.Data.Profunctor.Rep
-)
-where
-
-import Rebase.Data.Profunctor.Rep

--- a/library/Data/Profunctor/Sieve.hs
+++ b/library/Data/Profunctor/Sieve.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Sieve
-(
-  module Rebase.Data.Profunctor.Sieve
-)
-where
-
-import Rebase.Data.Profunctor.Sieve

--- a/library/Data/Profunctor/Strong.hs
+++ b/library/Data/Profunctor/Strong.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Strong
-(
-  module Rebase.Data.Profunctor.Strong
-)
-where
-
-import Rebase.Data.Profunctor.Strong

--- a/library/Data/Profunctor/Traversing.hs
+++ b/library/Data/Profunctor/Traversing.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Traversing
-(
-  module Rebase.Data.Profunctor.Traversing
-)
-where
-
-import Rebase.Data.Profunctor.Traversing

--- a/library/Data/Profunctor/Types.hs
+++ b/library/Data/Profunctor/Types.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Types
-(
-  module Rebase.Data.Profunctor.Types
-)
-where
-
-import Rebase.Data.Profunctor.Types

--- a/library/Data/Profunctor/Unsafe.hs
+++ b/library/Data/Profunctor/Unsafe.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Unsafe
-(
-  module Rebase.Data.Profunctor.Unsafe
-)
-where
-
-import Rebase.Data.Profunctor.Unsafe

--- a/library/Data/Profunctor/Yoneda.hs
+++ b/library/Data/Profunctor/Yoneda.hs
@@ -1,7 +1,0 @@
-module Data.Profunctor.Yoneda
-(
-  module Rebase.Data.Profunctor.Yoneda
-)
-where
-
-import Rebase.Data.Profunctor.Yoneda

--- a/library/Data/Proxy.hs
+++ b/library/Data/Proxy.hs
@@ -1,7 +1,0 @@
-module Data.Proxy
-(
-  module Rebase.Data.Proxy
-)
-where
-
-import Rebase.Data.Proxy

--- a/library/Data/Ratio.hs
+++ b/library/Data/Ratio.hs
@@ -1,7 +1,0 @@
-module Data.Ratio
-(
-  module Rebase.Data.Ratio
-)
-where
-
-import Rebase.Data.Ratio

--- a/library/Data/STRef.hs
+++ b/library/Data/STRef.hs
@@ -1,7 +1,0 @@
-module Data.STRef
-(
-  module Rebase.Data.STRef
-)
-where
-
-import Rebase.Data.STRef

--- a/library/Data/STRef/Lazy.hs
+++ b/library/Data/STRef/Lazy.hs
@@ -1,7 +1,0 @@
-module Data.STRef.Lazy
-(
-  module Rebase.Data.STRef.Lazy
-)
-where
-
-import Rebase.Data.STRef.Lazy

--- a/library/Data/STRef/Strict.hs
+++ b/library/Data/STRef/Strict.hs
@@ -1,7 +1,0 @@
-module Data.STRef.Strict
-(
-  module Rebase.Data.STRef.Strict
-)
-where
-
-import Rebase.Data.STRef.Strict

--- a/library/Data/Scientific.hs
+++ b/library/Data/Scientific.hs
@@ -1,7 +1,0 @@
-module Data.Scientific
-(
-  module Rebase.Data.Scientific
-)
-where
-
-import Rebase.Data.Scientific

--- a/library/Data/Semigroup.hs
+++ b/library/Data/Semigroup.hs
@@ -1,7 +1,0 @@
-module Data.Semigroup
-(
-  module Rebase.Data.Semigroup
-)
-where
-
-import Rebase.Data.Semigroup

--- a/library/Data/Semigroup/Bifoldable.hs
+++ b/library/Data/Semigroup/Bifoldable.hs
@@ -1,7 +1,0 @@
-module Data.Semigroup.Bifoldable
-(
-  module Rebase.Data.Semigroup.Bifoldable
-)
-where
-
-import Rebase.Data.Semigroup.Bifoldable

--- a/library/Data/Semigroup/Bitraversable.hs
+++ b/library/Data/Semigroup/Bitraversable.hs
@@ -1,7 +1,0 @@
-module Data.Semigroup.Bitraversable
-(
-  module Rebase.Data.Semigroup.Bitraversable
-)
-where
-
-import Rebase.Data.Semigroup.Bitraversable

--- a/library/Data/Semigroup/Foldable.hs
+++ b/library/Data/Semigroup/Foldable.hs
@@ -1,7 +1,0 @@
-module Data.Semigroup.Foldable
-(
-  module Rebase.Data.Semigroup.Foldable
-)
-where
-
-import Rebase.Data.Semigroup.Foldable

--- a/library/Data/Semigroup/Traversable.hs
+++ b/library/Data/Semigroup/Traversable.hs
@@ -1,7 +1,0 @@
-module Data.Semigroup.Traversable
-(
-  module Rebase.Data.Semigroup.Traversable
-)
-where
-
-import Rebase.Data.Semigroup.Traversable

--- a/library/Data/Semigroup/Traversable/Class.hs
+++ b/library/Data/Semigroup/Traversable/Class.hs
@@ -1,7 +1,0 @@
-module Data.Semigroup.Traversable.Class
-(
-  module Rebase.Data.Semigroup.Traversable.Class
-)
-where
-
-import Rebase.Data.Semigroup.Traversable.Class

--- a/library/Data/Semigroupoid.hs
+++ b/library/Data/Semigroupoid.hs
@@ -1,7 +1,0 @@
-module Data.Semigroupoid
-(
-  module Rebase.Data.Semigroupoid
-)
-where
-
-import Rebase.Data.Semigroupoid

--- a/library/Data/Semigroupoid/Dual.hs
+++ b/library/Data/Semigroupoid/Dual.hs
@@ -1,7 +1,0 @@
-module Data.Semigroupoid.Dual
-(
-  module Rebase.Data.Semigroupoid.Dual
-)
-where
-
-import Rebase.Data.Semigroupoid.Dual

--- a/library/Data/Semigroupoid/Ob.hs
+++ b/library/Data/Semigroupoid/Ob.hs
@@ -1,7 +1,0 @@
-module Data.Semigroupoid.Ob
-(
-  module Rebase.Data.Semigroupoid.Ob
-)
-where
-
-import Rebase.Data.Semigroupoid.Ob

--- a/library/Data/Semigroupoid/Static.hs
+++ b/library/Data/Semigroupoid/Static.hs
@@ -1,7 +1,0 @@
-module Data.Semigroupoid.Static
-(
-  module Rebase.Data.Semigroupoid.Static
-)
-where
-
-import Rebase.Data.Semigroupoid.Static

--- a/library/Data/Sequence.hs
+++ b/library/Data/Sequence.hs
@@ -1,7 +1,0 @@
-module Data.Sequence
-(
-  module Rebase.Data.Sequence
-)
-where
-
-import Rebase.Data.Sequence

--- a/library/Data/Set.hs
+++ b/library/Data/Set.hs
@@ -1,7 +1,0 @@
-module Data.Set
-(
-  module Rebase.Data.Set
-)
-where
-
-import Rebase.Data.Set

--- a/library/Data/String.hs
+++ b/library/Data/String.hs
@@ -1,7 +1,0 @@
-module Data.String
-(
-  module Rebase.Data.String
-)
-where
-
-import Rebase.Data.String

--- a/library/Data/Text.hs
+++ b/library/Data/Text.hs
@@ -1,7 +1,0 @@
-module Data.Text
-(
-  module Rebase.Data.Text
-)
-where
-
-import Rebase.Data.Text

--- a/library/Data/Text/Array.hs
+++ b/library/Data/Text/Array.hs
@@ -1,7 +1,0 @@
-module Data.Text.Array
-(
-  module Rebase.Data.Text.Array
-)
-where
-
-import Rebase.Data.Text.Array

--- a/library/Data/Text/Encoding.hs
+++ b/library/Data/Text/Encoding.hs
@@ -1,7 +1,0 @@
-module Data.Text.Encoding
-(
-  module Rebase.Data.Text.Encoding
-)
-where
-
-import Rebase.Data.Text.Encoding

--- a/library/Data/Text/Encoding/Error.hs
+++ b/library/Data/Text/Encoding/Error.hs
@@ -1,7 +1,0 @@
-module Data.Text.Encoding.Error
-(
-  module Rebase.Data.Text.Encoding.Error
-)
-where
-
-import Rebase.Data.Text.Encoding.Error

--- a/library/Data/Text/Foreign.hs
+++ b/library/Data/Text/Foreign.hs
@@ -1,7 +1,0 @@
-module Data.Text.Foreign
-(
-  module Rebase.Data.Text.Foreign
-)
-where
-
-import Rebase.Data.Text.Foreign

--- a/library/Data/Text/IO.hs
+++ b/library/Data/Text/IO.hs
@@ -1,7 +1,0 @@
-module Data.Text.IO
-(
-  module Rebase.Data.Text.IO
-)
-where
-
-import Rebase.Data.Text.IO

--- a/library/Data/Text/Internal.hs
+++ b/library/Data/Text/Internal.hs
@@ -1,7 +1,0 @@
-module Data.Text.Internal
-(
-  module Rebase.Data.Text.Internal
-)
-where
-
-import Rebase.Data.Text.Internal

--- a/library/Data/Text/Lazy.hs
+++ b/library/Data/Text/Lazy.hs
@@ -1,7 +1,0 @@
-module Data.Text.Lazy
-(
-  module Rebase.Data.Text.Lazy
-)
-where
-
-import Rebase.Data.Text.Lazy

--- a/library/Data/Text/Lazy/Builder.hs
+++ b/library/Data/Text/Lazy/Builder.hs
@@ -1,7 +1,0 @@
-module Data.Text.Lazy.Builder
-(
-  module Rebase.Data.Text.Lazy.Builder
-)
-where
-
-import Rebase.Data.Text.Lazy.Builder

--- a/library/Data/Text/Lazy/Builder/Int.hs
+++ b/library/Data/Text/Lazy/Builder/Int.hs
@@ -1,7 +1,0 @@
-module Data.Text.Lazy.Builder.Int
-(
-  module Rebase.Data.Text.Lazy.Builder.Int
-)
-where
-
-import Rebase.Data.Text.Lazy.Builder.Int

--- a/library/Data/Text/Lazy/Builder/RealFloat.hs
+++ b/library/Data/Text/Lazy/Builder/RealFloat.hs
@@ -1,7 +1,0 @@
-module Data.Text.Lazy.Builder.RealFloat
-(
-  module Rebase.Data.Text.Lazy.Builder.RealFloat
-)
-where
-
-import Rebase.Data.Text.Lazy.Builder.RealFloat

--- a/library/Data/Text/Lazy/Builder/Scientific.hs
+++ b/library/Data/Text/Lazy/Builder/Scientific.hs
@@ -1,7 +1,0 @@
-module Data.Text.Lazy.Builder.Scientific
-(
-  module Rebase.Data.Text.Lazy.Builder.Scientific
-)
-where
-
-import Rebase.Data.Text.Lazy.Builder.Scientific

--- a/library/Data/Text/Lazy/Encoding.hs
+++ b/library/Data/Text/Lazy/Encoding.hs
@@ -1,7 +1,0 @@
-module Data.Text.Lazy.Encoding
-(
-  module Rebase.Data.Text.Lazy.Encoding
-)
-where
-
-import Rebase.Data.Text.Lazy.Encoding

--- a/library/Data/Text/Lazy/IO.hs
+++ b/library/Data/Text/Lazy/IO.hs
@@ -1,7 +1,0 @@
-module Data.Text.Lazy.IO
-(
-  module Rebase.Data.Text.Lazy.IO
-)
-where
-
-import Rebase.Data.Text.Lazy.IO

--- a/library/Data/Text/Lazy/Read.hs
+++ b/library/Data/Text/Lazy/Read.hs
@@ -1,7 +1,0 @@
-module Data.Text.Lazy.Read
-(
-  module Rebase.Data.Text.Lazy.Read
-)
-where
-
-import Rebase.Data.Text.Lazy.Read

--- a/library/Data/Text/Read.hs
+++ b/library/Data/Text/Read.hs
@@ -1,7 +1,0 @@
-module Data.Text.Read
-(
-  module Rebase.Data.Text.Read
-)
-where
-
-import Rebase.Data.Text.Read

--- a/library/Data/Text/Unsafe.hs
+++ b/library/Data/Text/Unsafe.hs
@@ -1,7 +1,0 @@
-module Data.Text.Unsafe
-(
-  module Rebase.Data.Text.Unsafe
-)
-where
-
-import Rebase.Data.Text.Unsafe

--- a/library/Data/Time.hs
+++ b/library/Data/Time.hs
@@ -1,7 +1,0 @@
-module Data.Time
-(
-  module Rebase.Data.Time
-)
-where
-
-import Rebase.Data.Time

--- a/library/Data/Time/Calendar.hs
+++ b/library/Data/Time/Calendar.hs
@@ -1,7 +1,0 @@
-module Data.Time.Calendar
-(
-  module Rebase.Data.Time.Calendar
-)
-where
-
-import Rebase.Data.Time.Calendar

--- a/library/Data/Time/Calendar/Easter.hs
+++ b/library/Data/Time/Calendar/Easter.hs
@@ -1,7 +1,0 @@
-module Data.Time.Calendar.Easter
-(
-  module Rebase.Data.Time.Calendar.Easter
-)
-where
-
-import Rebase.Data.Time.Calendar.Easter

--- a/library/Data/Time/Calendar/Julian.hs
+++ b/library/Data/Time/Calendar/Julian.hs
@@ -1,7 +1,0 @@
-module Data.Time.Calendar.Julian
-(
-  module Rebase.Data.Time.Calendar.Julian
-)
-where
-
-import Rebase.Data.Time.Calendar.Julian

--- a/library/Data/Time/Calendar/MonthDay.hs
+++ b/library/Data/Time/Calendar/MonthDay.hs
@@ -1,7 +1,0 @@
-module Data.Time.Calendar.MonthDay
-(
-  module Rebase.Data.Time.Calendar.MonthDay
-)
-where
-
-import Rebase.Data.Time.Calendar.MonthDay

--- a/library/Data/Time/Calendar/OrdinalDate.hs
+++ b/library/Data/Time/Calendar/OrdinalDate.hs
@@ -1,7 +1,0 @@
-module Data.Time.Calendar.OrdinalDate
-(
-  module Rebase.Data.Time.Calendar.OrdinalDate
-)
-where
-
-import Rebase.Data.Time.Calendar.OrdinalDate

--- a/library/Data/Time/Calendar/WeekDate.hs
+++ b/library/Data/Time/Calendar/WeekDate.hs
@@ -1,7 +1,0 @@
-module Data.Time.Calendar.WeekDate
-(
-  module Rebase.Data.Time.Calendar.WeekDate
-)
-where
-
-import Rebase.Data.Time.Calendar.WeekDate

--- a/library/Data/Time/Clock.hs
+++ b/library/Data/Time/Clock.hs
@@ -1,7 +1,0 @@
-module Data.Time.Clock
-(
-  module Rebase.Data.Time.Clock
-)
-where
-
-import Rebase.Data.Time.Clock

--- a/library/Data/Time/Clock/POSIX.hs
+++ b/library/Data/Time/Clock/POSIX.hs
@@ -1,7 +1,0 @@
-module Data.Time.Clock.POSIX
-(
-  module Rebase.Data.Time.Clock.POSIX
-)
-where
-
-import Rebase.Data.Time.Clock.POSIX

--- a/library/Data/Time/Clock/TAI.hs
+++ b/library/Data/Time/Clock/TAI.hs
@@ -1,7 +1,0 @@
-module Data.Time.Clock.TAI
-(
-  module Rebase.Data.Time.Clock.TAI
-)
-where
-
-import Rebase.Data.Time.Clock.TAI

--- a/library/Data/Time/Compat.hs
+++ b/library/Data/Time/Compat.hs
@@ -1,7 +1,0 @@
-module Data.Time.Compat
-(
-  module Rebase.Data.Time.Compat
-)
-where
-
-import Rebase.Data.Time.Compat

--- a/library/Data/Time/Format.hs
+++ b/library/Data/Time/Format.hs
@@ -1,7 +1,0 @@
-module Data.Time.Format
-(
-  module Rebase.Data.Time.Format
-)
-where
-
-import Rebase.Data.Time.Format

--- a/library/Data/Time/Format/ISO8601.hs
+++ b/library/Data/Time/Format/ISO8601.hs
@@ -1,7 +1,0 @@
-module Data.Time.Format.ISO8601
-(
-  module Rebase.Data.Time.Format.ISO8601
-)
-where
-
-import Rebase.Data.Time.Format.ISO8601

--- a/library/Data/Time/LocalTime.hs
+++ b/library/Data/Time/LocalTime.hs
@@ -1,7 +1,0 @@
-module Data.Time.LocalTime
-(
-  module Rebase.Data.Time.LocalTime
-)
-where
-
-import Rebase.Data.Time.LocalTime

--- a/library/Data/Traversable.hs
+++ b/library/Data/Traversable.hs
@@ -1,7 +1,0 @@
-module Data.Traversable
-(
-  module Rebase.Data.Traversable
-)
-where
-
-import Rebase.Data.Traversable

--- a/library/Data/Traversable/Instances.hs
+++ b/library/Data/Traversable/Instances.hs
@@ -1,3 +1,0 @@
-module Data.Traversable.Instances where
-
-import Rebase.Data.Traversable.Instances ()

--- a/library/Data/Tree.hs
+++ b/library/Data/Tree.hs
@@ -1,7 +1,0 @@
-module Data.Tree
-(
-  module Rebase.Data.Tree
-)
-where
-
-import Rebase.Data.Tree

--- a/library/Data/Tuple.hs
+++ b/library/Data/Tuple.hs
@@ -1,7 +1,0 @@
-module Data.Tuple
-(
-  module Rebase.Data.Tuple
-)
-where
-
-import Rebase.Data.Tuple

--- a/library/Data/Type/Bool.hs
+++ b/library/Data/Type/Bool.hs
@@ -1,7 +1,0 @@
-module Data.Type.Bool
-(
-  module Rebase.Data.Type.Bool
-)
-where
-
-import Rebase.Data.Type.Bool

--- a/library/Data/Type/Coercion.hs
+++ b/library/Data/Type/Coercion.hs
@@ -1,7 +1,0 @@
-module Data.Type.Coercion
-(
-  module Rebase.Data.Type.Coercion
-)
-where
-
-import Rebase.Data.Type.Coercion

--- a/library/Data/Type/Equality.hs
+++ b/library/Data/Type/Equality.hs
@@ -1,7 +1,0 @@
-module Data.Type.Equality
-(
-  module Rebase.Data.Type.Equality
-)
-where
-
-import Rebase.Data.Type.Equality

--- a/library/Data/Typeable.hs
+++ b/library/Data/Typeable.hs
@@ -1,7 +1,0 @@
-module Data.Typeable
-(
-  module Rebase.Data.Typeable
-)
-where
-
-import Rebase.Data.Typeable

--- a/library/Data/UUID.hs
+++ b/library/Data/UUID.hs
@@ -1,7 +1,0 @@
-module Data.UUID
-(
-  module Rebase.Data.UUID
-)
-where
-
-import Rebase.Data.UUID

--- a/library/Data/Unique.hs
+++ b/library/Data/Unique.hs
@@ -1,7 +1,0 @@
-module Data.Unique
-(
-  module Rebase.Data.Unique
-)
-where
-
-import Rebase.Data.Unique

--- a/library/Data/Vector.hs
+++ b/library/Data/Vector.hs
@@ -1,7 +1,0 @@
-module Data.Vector
-(
-  module Rebase.Data.Vector
-)
-where
-
-import Rebase.Data.Vector

--- a/library/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/library/Data/Vector/Fusion/Stream/Monadic.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Fusion.Stream.Monadic
-(
-  module Rebase.Data.Vector.Fusion.Stream.Monadic
-)
-where
-
-import Rebase.Data.Vector.Fusion.Stream.Monadic

--- a/library/Data/Vector/Fusion/Util.hs
+++ b/library/Data/Vector/Fusion/Util.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Fusion.Util
-(
-  module Rebase.Data.Vector.Fusion.Util
-)
-where
-
-import Rebase.Data.Vector.Fusion.Util

--- a/library/Data/Vector/Generic.hs
+++ b/library/Data/Vector/Generic.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Generic
-(
-  module Rebase.Data.Vector.Generic
-)
-where
-
-import Rebase.Data.Vector.Generic

--- a/library/Data/Vector/Generic/Base.hs
+++ b/library/Data/Vector/Generic/Base.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Generic.Base
-(
-  module Rebase.Data.Vector.Generic.Base
-)
-where
-
-import Rebase.Data.Vector.Generic.Base

--- a/library/Data/Vector/Generic/Mutable.hs
+++ b/library/Data/Vector/Generic/Mutable.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Generic.Mutable
-(
-  module Rebase.Data.Vector.Generic.Mutable
-)
-where
-
-import Rebase.Data.Vector.Generic.Mutable

--- a/library/Data/Vector/Generic/New.hs
+++ b/library/Data/Vector/Generic/New.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Generic.New
-(
-  module Rebase.Data.Vector.Generic.New
-)
-where
-
-import Rebase.Data.Vector.Generic.New

--- a/library/Data/Vector/Instances.hs
+++ b/library/Data/Vector/Instances.hs
@@ -1,3 +1,0 @@
-module Data.Vector.Instances where
-
-import Rebase.Data.Vector.Instances ()

--- a/library/Data/Vector/Internal/Check.hs
+++ b/library/Data/Vector/Internal/Check.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Internal.Check
-(
-  module Rebase.Data.Vector.Internal.Check
-)
-where
-
-import Rebase.Data.Vector.Internal.Check

--- a/library/Data/Vector/Mutable.hs
+++ b/library/Data/Vector/Mutable.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Mutable
-(
-  module Rebase.Data.Vector.Mutable
-)
-where
-
-import Rebase.Data.Vector.Mutable

--- a/library/Data/Vector/Primitive.hs
+++ b/library/Data/Vector/Primitive.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Primitive
-(
-  module Rebase.Data.Vector.Primitive
-)
-where
-
-import Rebase.Data.Vector.Primitive

--- a/library/Data/Vector/Primitive/Mutable.hs
+++ b/library/Data/Vector/Primitive/Mutable.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Primitive.Mutable
-(
-  module Rebase.Data.Vector.Primitive.Mutable
-)
-where
-
-import Rebase.Data.Vector.Primitive.Mutable

--- a/library/Data/Vector/Storable.hs
+++ b/library/Data/Vector/Storable.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Storable
-(
-  module Rebase.Data.Vector.Storable
-)
-where
-
-import Rebase.Data.Vector.Storable

--- a/library/Data/Vector/Storable/Internal.hs
+++ b/library/Data/Vector/Storable/Internal.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Storable.Internal
-(
-  module Rebase.Data.Vector.Storable.Internal
-)
-where
-
-import Rebase.Data.Vector.Storable.Internal

--- a/library/Data/Vector/Storable/Mutable.hs
+++ b/library/Data/Vector/Storable/Mutable.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Storable.Mutable
-(
-  module Rebase.Data.Vector.Storable.Mutable
-)
-where
-
-import Rebase.Data.Vector.Storable.Mutable

--- a/library/Data/Vector/Unboxed.hs
+++ b/library/Data/Vector/Unboxed.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Unboxed
-(
-  module Rebase.Data.Vector.Unboxed
-)
-where
-
-import Rebase.Data.Vector.Unboxed

--- a/library/Data/Vector/Unboxed/Base.hs
+++ b/library/Data/Vector/Unboxed/Base.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Unboxed.Base
-(
-  module Rebase.Data.Vector.Unboxed.Base
-)
-where
-
-import Rebase.Data.Vector.Unboxed.Base

--- a/library/Data/Vector/Unboxed/Mutable.hs
+++ b/library/Data/Vector/Unboxed/Mutable.hs
@@ -1,7 +1,0 @@
-module Data.Vector.Unboxed.Mutable
-(
-  module Rebase.Data.Vector.Unboxed.Mutable
-)
-where
-
-import Rebase.Data.Vector.Unboxed.Mutable

--- a/library/Data/Version.hs
+++ b/library/Data/Version.hs
@@ -1,7 +1,0 @@
-module Data.Version
-(
-  module Rebase.Data.Version
-)
-where
-
-import Rebase.Data.Version

--- a/library/Data/Void.hs
+++ b/library/Data/Void.hs
@@ -1,7 +1,0 @@
-module Data.Void
-(
-  module Rebase.Data.Void
-)
-where
-
-import Rebase.Data.Void

--- a/library/Data/Void/Unsafe.hs
+++ b/library/Data/Void/Unsafe.hs
@@ -1,7 +1,0 @@
-module Data.Void.Unsafe
-(
-  module Rebase.Data.Void.Unsafe
-)
-where
-
-import Rebase.Data.Void.Unsafe

--- a/library/Data/Word.hs
+++ b/library/Data/Word.hs
@@ -1,7 +1,0 @@
-module Data.Word
-(
-  module Rebase.Data.Word
-)
-where
-
-import Rebase.Data.Word

--- a/library/Debug/Trace.hs
+++ b/library/Debug/Trace.hs
@@ -1,7 +1,0 @@
-module Debug.Trace
-(
-  module Rebase.Debug.Trace
-)
-where
-
-import Rebase.Debug.Trace

--- a/library/Foreign.hs
+++ b/library/Foreign.hs
@@ -1,7 +1,0 @@
-module Foreign
-(
-  module Rebase.Foreign
-)
-where
-
-import Rebase.Foreign

--- a/library/Foreign/C.hs
+++ b/library/Foreign/C.hs
@@ -1,7 +1,0 @@
-module Foreign.C
-(
-  module Rebase.Foreign.C
-)
-where
-
-import Rebase.Foreign.C

--- a/library/Foreign/C/Error.hs
+++ b/library/Foreign/C/Error.hs
@@ -1,7 +1,0 @@
-module Foreign.C.Error
-(
-  module Rebase.Foreign.C.Error
-)
-where
-
-import Rebase.Foreign.C.Error

--- a/library/Foreign/C/String.hs
+++ b/library/Foreign/C/String.hs
@@ -1,7 +1,0 @@
-module Foreign.C.String
-(
-  module Rebase.Foreign.C.String
-)
-where
-
-import Rebase.Foreign.C.String

--- a/library/Foreign/C/Types.hs
+++ b/library/Foreign/C/Types.hs
@@ -1,7 +1,0 @@
-module Foreign.C.Types
-(
-  module Rebase.Foreign.C.Types
-)
-where
-
-import Rebase.Foreign.C.Types

--- a/library/Foreign/Concurrent.hs
+++ b/library/Foreign/Concurrent.hs
@@ -1,7 +1,0 @@
-module Foreign.Concurrent
-(
-  module Rebase.Foreign.Concurrent
-)
-where
-
-import Rebase.Foreign.Concurrent

--- a/library/Foreign/ForeignPtr.hs
+++ b/library/Foreign/ForeignPtr.hs
@@ -1,7 +1,0 @@
-module Foreign.ForeignPtr
-(
-  module Rebase.Foreign.ForeignPtr
-)
-where
-
-import Rebase.Foreign.ForeignPtr

--- a/library/Foreign/ForeignPtr/Unsafe.hs
+++ b/library/Foreign/ForeignPtr/Unsafe.hs
@@ -1,7 +1,0 @@
-module Foreign.ForeignPtr.Unsafe
-(
-  module Rebase.Foreign.ForeignPtr.Unsafe
-)
-where
-
-import Rebase.Foreign.ForeignPtr.Unsafe

--- a/library/Foreign/Marshal.hs
+++ b/library/Foreign/Marshal.hs
@@ -1,7 +1,0 @@
-module Foreign.Marshal
-(
-  module Rebase.Foreign.Marshal
-)
-where
-
-import Rebase.Foreign.Marshal

--- a/library/Foreign/Marshal/Alloc.hs
+++ b/library/Foreign/Marshal/Alloc.hs
@@ -1,7 +1,0 @@
-module Foreign.Marshal.Alloc
-(
-  module Rebase.Foreign.Marshal.Alloc
-)
-where
-
-import Rebase.Foreign.Marshal.Alloc

--- a/library/Foreign/Marshal/Array.hs
+++ b/library/Foreign/Marshal/Array.hs
@@ -1,7 +1,0 @@
-module Foreign.Marshal.Array
-(
-  module Rebase.Foreign.Marshal.Array
-)
-where
-
-import Rebase.Foreign.Marshal.Array

--- a/library/Foreign/Marshal/Error.hs
+++ b/library/Foreign/Marshal/Error.hs
@@ -1,7 +1,0 @@
-module Foreign.Marshal.Error
-(
-  module Rebase.Foreign.Marshal.Error
-)
-where
-
-import Rebase.Foreign.Marshal.Error

--- a/library/Foreign/Marshal/Pool.hs
+++ b/library/Foreign/Marshal/Pool.hs
@@ -1,7 +1,0 @@
-module Foreign.Marshal.Pool
-(
-  module Rebase.Foreign.Marshal.Pool
-)
-where
-
-import Rebase.Foreign.Marshal.Pool

--- a/library/Foreign/Marshal/Safe.hs
+++ b/library/Foreign/Marshal/Safe.hs
@@ -1,7 +1,0 @@
-module Foreign.Marshal.Safe
-(
-  module Rebase.Foreign.Marshal.Safe
-)
-where
-
-import Rebase.Foreign.Marshal.Safe

--- a/library/Foreign/Marshal/Unsafe.hs
+++ b/library/Foreign/Marshal/Unsafe.hs
@@ -1,7 +1,0 @@
-module Foreign.Marshal.Unsafe
-(
-  module Rebase.Foreign.Marshal.Unsafe
-)
-where
-
-import Rebase.Foreign.Marshal.Unsafe

--- a/library/Foreign/Marshal/Utils.hs
+++ b/library/Foreign/Marshal/Utils.hs
@@ -1,7 +1,0 @@
-module Foreign.Marshal.Utils
-(
-  module Rebase.Foreign.Marshal.Utils
-)
-where
-
-import Rebase.Foreign.Marshal.Utils

--- a/library/Foreign/Ptr.hs
+++ b/library/Foreign/Ptr.hs
@@ -1,7 +1,0 @@
-module Foreign.Ptr
-(
-  module Rebase.Foreign.Ptr
-)
-where
-
-import Rebase.Foreign.Ptr

--- a/library/Foreign/StablePtr.hs
+++ b/library/Foreign/StablePtr.hs
@@ -1,7 +1,0 @@
-module Foreign.StablePtr
-(
-  module Rebase.Foreign.StablePtr
-)
-where
-
-import Rebase.Foreign.StablePtr

--- a/library/Foreign/Storable.hs
+++ b/library/Foreign/Storable.hs
@@ -1,7 +1,0 @@
-module Foreign.Storable
-(
-  module Rebase.Foreign.Storable
-)
-where
-
-import Rebase.Foreign.Storable

--- a/library/GHC/Arr.hs
+++ b/library/GHC/Arr.hs
@@ -1,7 +1,0 @@
-module GHC.Arr
-(
-  module Rebase.GHC.Arr
-)
-where
-
-import Rebase.GHC.Arr

--- a/library/GHC/Base.hs
+++ b/library/GHC/Base.hs
@@ -1,7 +1,0 @@
-module GHC.Base
-(
-  module Rebase.GHC.Base
-)
-where
-
-import Rebase.GHC.Base

--- a/library/GHC/Char.hs
+++ b/library/GHC/Char.hs
@@ -1,7 +1,0 @@
-module GHC.Char
-(
-  module Rebase.GHC.Char
-)
-where
-
-import Rebase.GHC.Char

--- a/library/GHC/Conc.hs
+++ b/library/GHC/Conc.hs
@@ -1,7 +1,0 @@
-module GHC.Conc
-(
-  module Rebase.GHC.Conc
-)
-where
-
-import Rebase.GHC.Conc

--- a/library/GHC/Conc/IO.hs
+++ b/library/GHC/Conc/IO.hs
@@ -1,7 +1,0 @@
-module GHC.Conc.IO
-(
-  module Rebase.GHC.Conc.IO
-)
-where
-
-import Rebase.GHC.Conc.IO

--- a/library/GHC/Conc/Signal.hs
+++ b/library/GHC/Conc/Signal.hs
@@ -1,7 +1,0 @@
-module GHC.Conc.Signal
-(
-  module Rebase.GHC.Conc.Signal
-)
-where
-
-import Rebase.GHC.Conc.Signal

--- a/library/GHC/Conc/Sync.hs
+++ b/library/GHC/Conc/Sync.hs
@@ -1,7 +1,0 @@
-module GHC.Conc.Sync
-(
-  module Rebase.GHC.Conc.Sync
-)
-where
-
-import Rebase.GHC.Conc.Sync

--- a/library/GHC/Enum.hs
+++ b/library/GHC/Enum.hs
@@ -1,7 +1,0 @@
-module GHC.Enum
-(
-  module Rebase.GHC.Enum
-)
-where
-
-import Rebase.GHC.Enum

--- a/library/GHC/Environment.hs
+++ b/library/GHC/Environment.hs
@@ -1,7 +1,0 @@
-module GHC.Environment
-(
-  module Rebase.GHC.Environment
-)
-where
-
-import Rebase.GHC.Environment

--- a/library/GHC/Err.hs
+++ b/library/GHC/Err.hs
@@ -1,7 +1,0 @@
-module GHC.Err
-(
-  module Rebase.GHC.Err
-)
-where
-
-import Rebase.GHC.Err

--- a/library/GHC/Exception.hs
+++ b/library/GHC/Exception.hs
@@ -1,7 +1,0 @@
-module GHC.Exception
-(
-  module Rebase.GHC.Exception
-)
-where
-
-import Rebase.GHC.Exception

--- a/library/GHC/Exts.hs
+++ b/library/GHC/Exts.hs
@@ -1,7 +1,0 @@
-module GHC.Exts
-(
-  module Rebase.GHC.Exts
-)
-where
-
-import Rebase.GHC.Exts

--- a/library/GHC/Fingerprint.hs
+++ b/library/GHC/Fingerprint.hs
@@ -1,7 +1,0 @@
-module GHC.Fingerprint
-(
-  module Rebase.GHC.Fingerprint
-)
-where
-
-import Rebase.GHC.Fingerprint

--- a/library/GHC/Fingerprint/Type.hs
+++ b/library/GHC/Fingerprint/Type.hs
@@ -1,7 +1,0 @@
-module GHC.Fingerprint.Type
-(
-  module Rebase.GHC.Fingerprint.Type
-)
-where
-
-import Rebase.GHC.Fingerprint.Type

--- a/library/GHC/Float.hs
+++ b/library/GHC/Float.hs
@@ -1,7 +1,0 @@
-module GHC.Float
-(
-  module Rebase.GHC.Float
-)
-where
-
-import Rebase.GHC.Float

--- a/library/GHC/Float/ConversionUtils.hs
+++ b/library/GHC/Float/ConversionUtils.hs
@@ -1,7 +1,0 @@
-module GHC.Float.ConversionUtils
-(
-  module Rebase.GHC.Float.ConversionUtils
-)
-where
-
-import Rebase.GHC.Float.ConversionUtils

--- a/library/GHC/Float/RealFracMethods.hs
+++ b/library/GHC/Float/RealFracMethods.hs
@@ -1,7 +1,0 @@
-module GHC.Float.RealFracMethods
-(
-  module Rebase.GHC.Float.RealFracMethods
-)
-where
-
-import Rebase.GHC.Float.RealFracMethods

--- a/library/GHC/Foreign.hs
+++ b/library/GHC/Foreign.hs
@@ -1,7 +1,0 @@
-module GHC.Foreign
-(
-  module Rebase.GHC.Foreign
-)
-where
-
-import Rebase.GHC.Foreign

--- a/library/GHC/ForeignPtr.hs
+++ b/library/GHC/ForeignPtr.hs
@@ -1,7 +1,0 @@
-module GHC.ForeignPtr
-(
-  module Rebase.GHC.ForeignPtr
-)
-where
-
-import Rebase.GHC.ForeignPtr

--- a/library/GHC/Generics.hs
+++ b/library/GHC/Generics.hs
@@ -1,7 +1,0 @@
-module GHC.Generics
-(
-  module Rebase.GHC.Generics
-)
-where
-
-import Rebase.GHC.Generics

--- a/library/GHC/IO.hs
+++ b/library/GHC/IO.hs
@@ -1,7 +1,0 @@
-module GHC.IO
-(
-  module Rebase.GHC.IO
-)
-where
-
-import Rebase.GHC.IO

--- a/library/GHC/IO/Buffer.hs
+++ b/library/GHC/IO/Buffer.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Buffer
-(
-  module Rebase.GHC.IO.Buffer
-)
-where
-
-import Rebase.GHC.IO.Buffer

--- a/library/GHC/IO/BufferedIO.hs
+++ b/library/GHC/IO/BufferedIO.hs
@@ -1,7 +1,0 @@
-module GHC.IO.BufferedIO
-(
-  module Rebase.GHC.IO.BufferedIO
-)
-where
-
-import Rebase.GHC.IO.BufferedIO

--- a/library/GHC/IO/Device.hs
+++ b/library/GHC/IO/Device.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Device
-(
-  module Rebase.GHC.IO.Device
-)
-where
-
-import Rebase.GHC.IO.Device

--- a/library/GHC/IO/Encoding.hs
+++ b/library/GHC/IO/Encoding.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Encoding
-(
-  module Rebase.GHC.IO.Encoding
-)
-where
-
-import Rebase.GHC.IO.Encoding

--- a/library/GHC/IO/Encoding/Failure.hs
+++ b/library/GHC/IO/Encoding/Failure.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Encoding.Failure
-(
-  module Rebase.GHC.IO.Encoding.Failure
-)
-where
-
-import Rebase.GHC.IO.Encoding.Failure

--- a/library/GHC/IO/Encoding/Iconv.hs
+++ b/library/GHC/IO/Encoding/Iconv.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Encoding.Iconv
-(
-  module Rebase.GHC.IO.Encoding.Iconv
-)
-where
-
-import Rebase.GHC.IO.Encoding.Iconv

--- a/library/GHC/IO/Encoding/Latin1.hs
+++ b/library/GHC/IO/Encoding/Latin1.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Encoding.Latin1
-(
-  module Rebase.GHC.IO.Encoding.Latin1
-)
-where
-
-import Rebase.GHC.IO.Encoding.Latin1

--- a/library/GHC/IO/Encoding/Types.hs
+++ b/library/GHC/IO/Encoding/Types.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Encoding.Types
-(
-  module Rebase.GHC.IO.Encoding.Types
-)
-where
-
-import Rebase.GHC.IO.Encoding.Types

--- a/library/GHC/IO/Encoding/UTF16.hs
+++ b/library/GHC/IO/Encoding/UTF16.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Encoding.UTF16
-(
-  module Rebase.GHC.IO.Encoding.UTF16
-)
-where
-
-import Rebase.GHC.IO.Encoding.UTF16

--- a/library/GHC/IO/Encoding/UTF32.hs
+++ b/library/GHC/IO/Encoding/UTF32.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Encoding.UTF32
-(
-  module Rebase.GHC.IO.Encoding.UTF32
-)
-where
-
-import Rebase.GHC.IO.Encoding.UTF32

--- a/library/GHC/IO/Encoding/UTF8.hs
+++ b/library/GHC/IO/Encoding/UTF8.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Encoding.UTF8
-(
-  module Rebase.GHC.IO.Encoding.UTF8
-)
-where
-
-import Rebase.GHC.IO.Encoding.UTF8

--- a/library/GHC/IO/Exception.hs
+++ b/library/GHC/IO/Exception.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Exception
-(
-  module Rebase.GHC.IO.Exception
-)
-where
-
-import Rebase.GHC.IO.Exception

--- a/library/GHC/IO/FD.hs
+++ b/library/GHC/IO/FD.hs
@@ -1,7 +1,0 @@
-module GHC.IO.FD
-(
-  module Rebase.GHC.IO.FD
-)
-where
-
-import Rebase.GHC.IO.FD

--- a/library/GHC/IO/Handle.hs
+++ b/library/GHC/IO/Handle.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Handle
-(
-  module Rebase.GHC.IO.Handle
-)
-where
-
-import Rebase.GHC.IO.Handle

--- a/library/GHC/IO/Handle/FD.hs
+++ b/library/GHC/IO/Handle/FD.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Handle.FD
-(
-  module Rebase.GHC.IO.Handle.FD
-)
-where
-
-import Rebase.GHC.IO.Handle.FD

--- a/library/GHC/IO/Handle/Internals.hs
+++ b/library/GHC/IO/Handle/Internals.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Handle.Internals
-(
-  module Rebase.GHC.IO.Handle.Internals
-)
-where
-
-import Rebase.GHC.IO.Handle.Internals

--- a/library/GHC/IO/Handle/Text.hs
+++ b/library/GHC/IO/Handle/Text.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Handle.Text
-(
-  module Rebase.GHC.IO.Handle.Text
-)
-where
-
-import Rebase.GHC.IO.Handle.Text

--- a/library/GHC/IO/Handle/Types.hs
+++ b/library/GHC/IO/Handle/Types.hs
@@ -1,7 +1,0 @@
-module GHC.IO.Handle.Types
-(
-  module Rebase.GHC.IO.Handle.Types
-)
-where
-
-import Rebase.GHC.IO.Handle.Types

--- a/library/GHC/IO/IOMode.hs
+++ b/library/GHC/IO/IOMode.hs
@@ -1,7 +1,0 @@
-module GHC.IO.IOMode
-(
-  module Rebase.GHC.IO.IOMode
-)
-where
-
-import Rebase.GHC.IO.IOMode

--- a/library/GHC/IOArray.hs
+++ b/library/GHC/IOArray.hs
@@ -1,7 +1,0 @@
-module GHC.IOArray
-(
-  module Rebase.GHC.IOArray
-)
-where
-
-import Rebase.GHC.IOArray

--- a/library/GHC/IORef.hs
+++ b/library/GHC/IORef.hs
@@ -1,7 +1,0 @@
-module GHC.IORef
-(
-  module Rebase.GHC.IORef
-)
-where
-
-import Rebase.GHC.IORef

--- a/library/GHC/Int.hs
+++ b/library/GHC/Int.hs
@@ -1,7 +1,0 @@
-module GHC.Int
-(
-  module Rebase.GHC.Int
-)
-where
-
-import Rebase.GHC.Int

--- a/library/GHC/List.hs
+++ b/library/GHC/List.hs
@@ -1,7 +1,0 @@
-module GHC.List
-(
-  module Rebase.GHC.List
-)
-where
-
-import Rebase.GHC.List

--- a/library/GHC/MVar.hs
+++ b/library/GHC/MVar.hs
@@ -1,7 +1,0 @@
-module GHC.MVar
-(
-  module Rebase.GHC.MVar
-)
-where
-
-import Rebase.GHC.MVar

--- a/library/GHC/Num.hs
+++ b/library/GHC/Num.hs
@@ -1,7 +1,0 @@
-module GHC.Num
-(
-  module Rebase.GHC.Num
-)
-where
-
-import Rebase.GHC.Num

--- a/library/GHC/OverloadedLabels.hs
+++ b/library/GHC/OverloadedLabels.hs
@@ -1,7 +1,0 @@
-module GHC.OverloadedLabels
-(
-  module Rebase.GHC.OverloadedLabels
-)
-where
-
-import Rebase.GHC.OverloadedLabels

--- a/library/GHC/PArr.hs
+++ b/library/GHC/PArr.hs
@@ -1,7 +1,0 @@
-module GHC.PArr
-(
-  module Rebase.GHC.PArr
-)
-where
-
-import Rebase.GHC.PArr

--- a/library/GHC/Profiling.hs
+++ b/library/GHC/Profiling.hs
@@ -1,7 +1,0 @@
-module GHC.Profiling
-(
-  module Rebase.GHC.Profiling
-)
-where
-
-import Rebase.GHC.Profiling

--- a/library/GHC/Ptr.hs
+++ b/library/GHC/Ptr.hs
@@ -1,7 +1,0 @@
-module GHC.Ptr
-(
-  module Rebase.GHC.Ptr
-)
-where
-
-import Rebase.GHC.Ptr

--- a/library/GHC/Read.hs
+++ b/library/GHC/Read.hs
@@ -1,7 +1,0 @@
-module GHC.Read
-(
-  module Rebase.GHC.Read
-)
-where
-
-import Rebase.GHC.Read

--- a/library/GHC/Real.hs
+++ b/library/GHC/Real.hs
@@ -1,7 +1,0 @@
-module GHC.Real
-(
-  module Rebase.GHC.Real
-)
-where
-
-import Rebase.GHC.Real

--- a/library/GHC/Records.hs
+++ b/library/GHC/Records.hs
@@ -1,7 +1,0 @@
-module GHC.Records
-(
-  module Rebase.GHC.Records
-)
-where
-
-import Rebase.GHC.Records

--- a/library/GHC/ST.hs
+++ b/library/GHC/ST.hs
@@ -1,7 +1,0 @@
-module GHC.ST
-(
-  module Rebase.GHC.ST
-)
-where
-
-import Rebase.GHC.ST

--- a/library/GHC/STRef.hs
+++ b/library/GHC/STRef.hs
@@ -1,7 +1,0 @@
-module GHC.STRef
-(
-  module Rebase.GHC.STRef
-)
-where
-
-import Rebase.GHC.STRef

--- a/library/GHC/Show.hs
+++ b/library/GHC/Show.hs
@@ -1,7 +1,0 @@
-module GHC.Show
-(
-  module Rebase.GHC.Show
-)
-where
-
-import Rebase.GHC.Show

--- a/library/GHC/Stable.hs
+++ b/library/GHC/Stable.hs
@@ -1,7 +1,0 @@
-module GHC.Stable
-(
-  module Rebase.GHC.Stable
-)
-where
-
-import Rebase.GHC.Stable

--- a/library/GHC/Stack.hs
+++ b/library/GHC/Stack.hs
@@ -1,7 +1,0 @@
-module GHC.Stack
-(
-  module Rebase.GHC.Stack
-)
-where
-
-import Rebase.GHC.Stack

--- a/library/GHC/Stats.hs
+++ b/library/GHC/Stats.hs
@@ -1,7 +1,0 @@
-module GHC.Stats
-(
-  module Rebase.GHC.Stats
-)
-where
-
-import Rebase.GHC.Stats

--- a/library/GHC/Storable.hs
+++ b/library/GHC/Storable.hs
@@ -1,7 +1,0 @@
-module GHC.Storable
-(
-  module Rebase.GHC.Storable
-)
-where
-
-import Rebase.GHC.Storable

--- a/library/GHC/TopHandler.hs
+++ b/library/GHC/TopHandler.hs
@@ -1,7 +1,0 @@
-module GHC.TopHandler
-(
-  module Rebase.GHC.TopHandler
-)
-where
-
-import Rebase.GHC.TopHandler

--- a/library/GHC/TypeLits.hs
+++ b/library/GHC/TypeLits.hs
@@ -1,7 +1,0 @@
-module GHC.TypeLits
-(
-  module Rebase.GHC.TypeLits
-)
-where
-
-import Rebase.GHC.TypeLits

--- a/library/GHC/TypeNats.hs
+++ b/library/GHC/TypeNats.hs
@@ -1,7 +1,0 @@
-module GHC.TypeNats
-(
-  module Rebase.GHC.TypeNats
-)
-where
-
-import Rebase.GHC.TypeNats

--- a/library/GHC/Unicode.hs
+++ b/library/GHC/Unicode.hs
@@ -1,7 +1,0 @@
-module GHC.Unicode
-(
-  module Rebase.GHC.Unicode
-)
-where
-
-import Rebase.GHC.Unicode

--- a/library/GHC/Weak.hs
+++ b/library/GHC/Weak.hs
@@ -1,7 +1,0 @@
-module GHC.Weak
-(
-  module Rebase.GHC.Weak
-)
-where
-
-import Rebase.GHC.Weak

--- a/library/GHC/Word.hs
+++ b/library/GHC/Word.hs
@@ -1,7 +1,0 @@
-module GHC.Word
-(
-  module Rebase.GHC.Word
-)
-where
-
-import Rebase.GHC.Word

--- a/library/Numeric.hs
+++ b/library/Numeric.hs
@@ -1,7 +1,0 @@
-module Numeric
-(
-  module Rebase.Numeric
-)
-where
-
-import Rebase.Numeric

--- a/library/Numeric/Natural.hs
+++ b/library/Numeric/Natural.hs
@@ -1,7 +1,0 @@
-module Numeric.Natural
-(
-  module Rebase.Numeric.Natural
-)
-where
-
-import Rebase.Numeric.Natural

--- a/library/Prelude.hs
+++ b/library/Prelude.hs
@@ -1,7 +1,0 @@
-module Prelude
-(
-  module Rebase.Prelude
-)
-where
-
-import Rebase.Prelude

--- a/library/System/CPUTime.hs
+++ b/library/System/CPUTime.hs
@@ -1,7 +1,0 @@
-module System.CPUTime
-(
-  module Rebase.System.CPUTime
-)
-where
-
-import Rebase.System.CPUTime

--- a/library/System/Console/GetOpt.hs
+++ b/library/System/Console/GetOpt.hs
@@ -1,7 +1,0 @@
-module System.Console.GetOpt
-(
-  module Rebase.System.Console.GetOpt
-)
-where
-
-import Rebase.System.Console.GetOpt

--- a/library/System/Environment.hs
+++ b/library/System/Environment.hs
@@ -1,7 +1,0 @@
-module System.Environment
-(
-  module Rebase.System.Environment
-)
-where
-
-import Rebase.System.Environment

--- a/library/System/Exit.hs
+++ b/library/System/Exit.hs
@@ -1,7 +1,0 @@
-module System.Exit
-(
-  module Rebase.System.Exit
-)
-where
-
-import Rebase.System.Exit

--- a/library/System/IO.hs
+++ b/library/System/IO.hs
@@ -1,7 +1,0 @@
-module System.IO
-(
-  module Rebase.System.IO
-)
-where
-
-import Rebase.System.IO

--- a/library/System/IO/Error.hs
+++ b/library/System/IO/Error.hs
@@ -1,7 +1,0 @@
-module System.IO.Error
-(
-  module Rebase.System.IO.Error
-)
-where
-
-import Rebase.System.IO.Error

--- a/library/System/IO/Unsafe.hs
+++ b/library/System/IO/Unsafe.hs
@@ -1,7 +1,0 @@
-module System.IO.Unsafe
-(
-  module Rebase.System.IO.Unsafe
-)
-where
-
-import Rebase.System.IO.Unsafe

--- a/library/System/Info.hs
+++ b/library/System/Info.hs
@@ -1,7 +1,0 @@
-module System.Info
-(
-  module Rebase.System.Info
-)
-where
-
-import Rebase.System.Info

--- a/library/System/Mem.hs
+++ b/library/System/Mem.hs
@@ -1,7 +1,0 @@
-module System.Mem
-(
-  module Rebase.System.Mem
-)
-where
-
-import Rebase.System.Mem

--- a/library/System/Mem/StableName.hs
+++ b/library/System/Mem/StableName.hs
@@ -1,7 +1,0 @@
-module System.Mem.StableName
-(
-  module Rebase.System.Mem.StableName
-)
-where
-
-import Rebase.System.Mem.StableName

--- a/library/System/Mem/Weak.hs
+++ b/library/System/Mem/Weak.hs
@@ -1,7 +1,0 @@
-module System.Mem.Weak
-(
-  module Rebase.System.Mem.Weak
-)
-where
-
-import Rebase.System.Mem.Weak

--- a/library/System/Posix/Internals.hs
+++ b/library/System/Posix/Internals.hs
@@ -1,7 +1,0 @@
-module System.Posix.Internals
-(
-  module Rebase.System.Posix.Internals
-)
-where
-
-import Rebase.System.Posix.Internals

--- a/library/System/Posix/Types.hs
+++ b/library/System/Posix/Types.hs
@@ -1,7 +1,0 @@
-module System.Posix.Types
-(
-  module Rebase.System.Posix.Types
-)
-where
-
-import Rebase.System.Posix.Types

--- a/library/System/Timeout.hs
+++ b/library/System/Timeout.hs
@@ -1,7 +1,0 @@
-module System.Timeout
-(
-  module Rebase.System.Timeout
-)
-where
-
-import Rebase.System.Timeout

--- a/library/Text/ParserCombinators/ReadP.hs
+++ b/library/Text/ParserCombinators/ReadP.hs
@@ -1,7 +1,0 @@
-module Text.ParserCombinators.ReadP
-(
-  module Rebase.Text.ParserCombinators.ReadP
-)
-where
-
-import Rebase.Text.ParserCombinators.ReadP

--- a/library/Text/ParserCombinators/ReadPrec.hs
+++ b/library/Text/ParserCombinators/ReadPrec.hs
@@ -1,7 +1,0 @@
-module Text.ParserCombinators.ReadPrec
-(
-  module Rebase.Text.ParserCombinators.ReadPrec
-)
-where
-
-import Rebase.Text.ParserCombinators.ReadPrec

--- a/library/Text/Printf.hs
+++ b/library/Text/Printf.hs
@@ -1,7 +1,0 @@
-module Text.Printf
-(
-  module Rebase.Text.Printf
-)
-where
-
-import Rebase.Text.Printf

--- a/library/Text/Read.hs
+++ b/library/Text/Read.hs
@@ -1,7 +1,0 @@
-module Text.Read
-(
-  module Rebase.Text.Read
-)
-where
-
-import Rebase.Text.Read

--- a/library/Text/Read/Lex.hs
+++ b/library/Text/Read/Lex.hs
@@ -1,7 +1,0 @@
-module Text.Read.Lex
-(
-  module Rebase.Text.Read.Lex
-)
-where
-
-import Rebase.Text.Read.Lex

--- a/library/Text/Show.hs
+++ b/library/Text/Show.hs
@@ -1,7 +1,0 @@
-module Text.Show
-(
-  module Rebase.Text.Show
-)
-where
-
-import Rebase.Text.Show

--- a/library/Unsafe/Coerce.hs
+++ b/library/Unsafe/Coerce.hs
@@ -1,7 +1,0 @@
-module Unsafe.Coerce
-(
-  module Rebase.Unsafe.Coerce
-)
-where
-
-import Rebase.Unsafe.Coerce

--- a/rerebase.cabal
+++ b/rerebase.cabal
@@ -22,376 +22,375 @@ source-repository head
   location: git://github.com/nikita-volkov/rerebase.git
 
 library
-  hs-source-dirs:   library
   default-language: Haskell2010
-  exposed-modules:
-    Control.Applicative
-    Control.Applicative.Backwards
-    Control.Applicative.Lift
-    Control.Arrow
-    Control.Category
-    Control.Comonad
-    Control.Concurrent
-    Control.Concurrent.Chan
-    Control.Concurrent.MVar
-    Control.Concurrent.QSem
-    Control.Concurrent.QSemN
-    Control.Concurrent.STM
-    Control.Concurrent.STM.TArray
-    Control.Concurrent.STM.TBQueue
-    Control.Concurrent.STM.TChan
-    Control.Concurrent.STM.TMVar
-    Control.Concurrent.STM.TQueue
-    Control.Concurrent.STM.TSem
-    Control.Concurrent.STM.TVar
-    Control.DeepSeq
-    Control.Exception
-    Control.Exception.Base
-    Control.Monad
-    Control.Monad.Cont
-    Control.Monad.Cont.Class
-    Control.Monad.Error.Class
-    Control.Monad.Fail
-    Control.Monad.Fix
-    Control.Monad.Identity
-    Control.Monad.IO.Class
-    Control.Monad.Reader
-    Control.Monad.Reader.Class
-    Control.Monad.RWS
-    Control.Monad.RWS.Class
-    Control.Monad.RWS.Lazy
-    Control.Monad.RWS.Strict
-    Control.Monad.Signatures
-    Control.Monad.ST
-    Control.Monad.ST.Lazy
-    Control.Monad.ST.Lazy.Unsafe
-    Control.Monad.ST.Strict
-    Control.Monad.ST.Unsafe
-    Control.Monad.State
-    Control.Monad.State.Class
-    Control.Monad.State.Lazy
-    Control.Monad.State.Strict
-    Control.Monad.STM
-    Control.Monad.Trans
-    Control.Monad.Trans.Class
-    Control.Monad.Trans.Cont
-    Control.Monad.Trans.Except
-    Control.Monad.Trans.Identity
-    Control.Monad.Trans.Maybe
-    Control.Monad.Trans.Reader
-    Control.Monad.Trans.RWS
-    Control.Monad.Trans.RWS.Lazy
-    Control.Monad.Trans.RWS.Strict
-    Control.Monad.Trans.State
-    Control.Monad.Trans.State.Lazy
-    Control.Monad.Trans.State.Strict
-    Control.Monad.Trans.Writer
-    Control.Monad.Trans.Writer.Lazy
-    Control.Monad.Trans.Writer.Strict
-    Control.Monad.Writer
-    Control.Monad.Writer.Class
-    Control.Monad.Writer.Lazy
-    Control.Monad.Writer.Strict
-    Control.Monad.Zip
-    Control.Selective
-    Control.Selective.Free
-    Control.Selective.Multi
-    Control.Selective.Rigid.Free
-    Control.Selective.Rigid.Freer
-    Data.Biapplicative
-    Data.Bifoldable
-    Data.Bifunctor
-    Data.Bifunctor.Apply
-    Data.Bifunctor.Biff
-    Data.Bifunctor.Clown
-    Data.Bifunctor.Flip
-    Data.Bifunctor.Join
-    Data.Bifunctor.Joker
-    Data.Bifunctor.Product
-    Data.Bifunctor.Tannen
-    Data.Bifunctor.Wrapped
-    Data.Bitraversable
-    Data.Bits
-    Data.Bool
-    Data.ByteString
-    Data.ByteString.Builder
-    Data.ByteString.Builder.Extra
-    Data.ByteString.Builder.Internal
-    Data.ByteString.Builder.Prim
-    Data.ByteString.Builder.Prim.Internal
-    Data.ByteString.Builder.Scientific
-    Data.ByteString.Char8
-    Data.ByteString.Internal
-    Data.ByteString.Lazy
-    Data.ByteString.Lazy.Char8
-    Data.ByteString.Lazy.Internal
-    Data.ByteString.Short
-    Data.ByteString.Short.Internal
-    Data.ByteString.Unsafe
-    Data.Char
-    Data.Coerce
-    Data.Complex
-    Data.Data
-    Data.DList
-    Data.Dynamic
-    Data.Either
-    Data.Either.Combinators
-    Data.Either.Validation
-    Data.Eq
-    Data.Fixed
-    Data.Foldable
-    Data.Function
-    Data.Functor
-    Data.Functor.Alt
-    Data.Functor.Apply
-    Data.Functor.Bind
-    Data.Functor.Bind.Class
-    Data.Functor.Bind.Trans
-    Data.Functor.Classes
-    Data.Functor.Compose
-    Data.Functor.Constant
-    Data.Functor.Contravariant
-    Data.Functor.Contravariant.Compose
-    Data.Functor.Contravariant.Divisible
-    Data.Functor.Extend
-    Data.Functor.Identity
-    Data.Functor.Invariant
-    Data.Functor.Invariant.TH
-    Data.Functor.Plus
-    Data.Functor.Product
-    Data.Functor.Reverse
-    Data.Functor.Sum
-    Data.Graph
-    Data.Group
-    Data.Groupoid
-    Data.Hashable
-    Data.HashMap.Lazy
-    Data.HashMap.Strict
-    Data.HashSet
-    Data.Int
-    Data.IntMap
-    Data.IntMap.Lazy
-    Data.IntMap.Strict
-    Data.IntSet
-    Data.IORef
-    Data.Isomorphism
-    Data.Ix
-    Data.Kind
-    Data.List
-    Data.List.NonEmpty
-    Data.Map
-    Data.Map.Lazy
-    Data.Map.Strict
-    Data.Maybe
-    Data.Monoid
-    Data.Ord
-    Data.Profunctor
-    Data.Profunctor.Adjunction
-    Data.Profunctor.Cayley
-    Data.Profunctor.Choice
-    Data.Profunctor.Closed
-    Data.Profunctor.Composition
-    Data.Profunctor.Mapping
-    Data.Profunctor.Monad
-    Data.Profunctor.Ran
-    Data.Profunctor.Rep
-    Data.Profunctor.Sieve
-    Data.Profunctor.Strong
-    Data.Profunctor.Traversing
-    Data.Profunctor.Types
-    Data.Profunctor.Unsafe
-    Data.Profunctor.Yoneda
-    Data.Proxy
-    Data.Ratio
-    Data.Scientific
-    Data.Semigroup
-    Data.Semigroup.Bifoldable
-    Data.Semigroup.Bitraversable
-    Data.Semigroup.Foldable
-    Data.Semigroup.Traversable
-    Data.Semigroup.Traversable.Class
-    Data.Semigroupoid
-    Data.Semigroupoid.Dual
-    Data.Semigroupoid.Ob
-    Data.Semigroupoid.Static
-    Data.Sequence
-    Data.Set
-    Data.STRef
-    Data.STRef.Lazy
-    Data.STRef.Strict
-    Data.String
-    Data.Text
-    Data.Text.Array
-    Data.Text.Encoding
-    Data.Text.Encoding.Error
-    Data.Text.Foreign
-    Data.Text.Internal
-    Data.Text.IO
-    Data.Text.Lazy
-    Data.Text.Lazy.Builder
-    Data.Text.Lazy.Builder.Int
-    Data.Text.Lazy.Builder.RealFloat
-    Data.Text.Lazy.Builder.Scientific
-    Data.Text.Lazy.Encoding
-    Data.Text.Lazy.IO
-    Data.Text.Lazy.Read
-    Data.Text.Read
-    Data.Text.Unsafe
-    Data.Time
-    Data.Time.Calendar
-    Data.Time.Calendar.Easter
-    Data.Time.Calendar.Julian
-    Data.Time.Calendar.MonthDay
-    Data.Time.Calendar.OrdinalDate
-    Data.Time.Calendar.WeekDate
-    Data.Time.Clock
-    Data.Time.Clock.POSIX
-    Data.Time.Clock.TAI
-    Data.Time.Compat
-    Data.Time.Format
-    Data.Time.Format.ISO8601
-    Data.Time.LocalTime
-    Data.Traversable
-    Data.Traversable.Instances
-    Data.Tree
-    Data.Tuple
-    Data.Type.Bool
-    Data.Type.Coercion
-    Data.Type.Equality
-    Data.Typeable
-    Data.Unique
-    Data.UUID
-    Data.Vector
-    Data.Vector.Fusion.Stream.Monadic
-    Data.Vector.Fusion.Util
-    Data.Vector.Generic
-    Data.Vector.Generic.Base
-    Data.Vector.Generic.Mutable
-    Data.Vector.Generic.New
-    Data.Vector.Instances
-    Data.Vector.Internal.Check
-    Data.Vector.Mutable
-    Data.Vector.Primitive
-    Data.Vector.Primitive.Mutable
-    Data.Vector.Storable
-    Data.Vector.Storable.Internal
-    Data.Vector.Storable.Mutable
-    Data.Vector.Unboxed
-    Data.Vector.Unboxed.Base
-    Data.Vector.Unboxed.Mutable
-    Data.Version
-    Data.Void
-    Data.Void.Unsafe
-    Data.Word
-    Debug.Trace
-    Foreign
-    Foreign.C
-    Foreign.C.Error
-    Foreign.C.String
-    Foreign.C.Types
-    Foreign.Concurrent
-    Foreign.ForeignPtr
-    Foreign.ForeignPtr.Unsafe
-    Foreign.Marshal
-    Foreign.Marshal.Alloc
-    Foreign.Marshal.Array
-    Foreign.Marshal.Error
-    Foreign.Marshal.Pool
-    Foreign.Marshal.Safe
-    Foreign.Marshal.Unsafe
-    Foreign.Marshal.Utils
-    Foreign.Ptr
-    Foreign.StablePtr
-    Foreign.Storable
-    GHC.Arr
-    GHC.Base
-    GHC.Char
-    GHC.Conc
-    GHC.Conc.IO
-    GHC.Conc.Signal
-    GHC.Conc.Sync
-    GHC.Enum
-    GHC.Environment
-    GHC.Err
-    GHC.Exception
-    GHC.Exts
-    GHC.Fingerprint
-    GHC.Fingerprint.Type
-    GHC.Float
-    GHC.Float.ConversionUtils
-    GHC.Float.RealFracMethods
-    GHC.Foreign
-    GHC.ForeignPtr
-    GHC.Generics
-    GHC.Int
-    GHC.IO
-    GHC.IO.Buffer
-    GHC.IO.BufferedIO
-    GHC.IO.Device
-    GHC.IO.Encoding
-    GHC.IO.Encoding.Failure
-    GHC.IO.Encoding.Iconv
-    GHC.IO.Encoding.Latin1
-    GHC.IO.Encoding.Types
-    GHC.IO.Encoding.UTF16
-    GHC.IO.Encoding.UTF32
-    GHC.IO.Encoding.UTF8
-    GHC.IO.Exception
-    GHC.IO.FD
-    GHC.IO.Handle
-    GHC.IO.Handle.FD
-    GHC.IO.Handle.Internals
-    GHC.IO.Handle.Text
-    GHC.IO.Handle.Types
-    GHC.IO.IOMode
-    GHC.IOArray
-    GHC.IORef
-    GHC.List
-    GHC.MVar
-    GHC.Num
-    GHC.OverloadedLabels
-    GHC.Profiling
-    GHC.Ptr
-    GHC.Read
-    GHC.Real
-    GHC.Records
-    GHC.Show
-    GHC.ST
-    GHC.Stable
-    GHC.Stack
-    GHC.Stats
-    GHC.Storable
-    GHC.STRef
-    GHC.TopHandler
-    GHC.TypeLits
-    GHC.TypeNats
-    GHC.Unicode
-    GHC.Weak
-    GHC.Word
-    Numeric
-    Numeric.Natural
-    Prelude
-    System.Console.GetOpt
-    System.CPUTime
-    System.Environment
-    System.Exit
-    System.Info
-    System.IO
-    System.IO.Error
-    System.IO.Unsafe
-    System.Mem
-    System.Mem.StableName
-    System.Mem.Weak
-    System.Posix.Internals
-    System.Posix.Types
-    System.Timeout
-    Text.ParserCombinators.ReadP
-    Text.ParserCombinators.ReadPrec
-    Text.Printf
-    Text.Read
-    Text.Read.Lex
-    Text.Show
-    Unsafe.Coerce
+  reexported-modules:
+    Rebase.Control.Applicative as Control.Applicative,
+    Rebase.Control.Applicative.Backwards as Control.Applicative.Backwards,
+    Rebase.Control.Applicative.Lift as Control.Applicative.Lift,
+    Rebase.Control.Arrow as Control.Arrow,
+    Rebase.Control.Category as Control.Category,
+    Rebase.Control.Comonad as Control.Comonad,
+    Rebase.Control.Concurrent as Control.Concurrent,
+    Rebase.Control.Concurrent.Chan as Control.Concurrent.Chan,
+    Rebase.Control.Concurrent.MVar as Control.Concurrent.MVar,
+    Rebase.Control.Concurrent.QSem as Control.Concurrent.QSem,
+    Rebase.Control.Concurrent.QSemN as Control.Concurrent.QSemN,
+    Rebase.Control.Concurrent.STM as Control.Concurrent.STM,
+    Rebase.Control.Concurrent.STM.TArray as Control.Concurrent.STM.TArray,
+    Rebase.Control.Concurrent.STM.TBQueue as Control.Concurrent.STM.TBQueue,
+    Rebase.Control.Concurrent.STM.TChan as Control.Concurrent.STM.TChan,
+    Rebase.Control.Concurrent.STM.TMVar as Control.Concurrent.STM.TMVar,
+    Rebase.Control.Concurrent.STM.TQueue as Control.Concurrent.STM.TQueue,
+    Rebase.Control.Concurrent.STM.TSem as Control.Concurrent.STM.TSem,
+    Rebase.Control.Concurrent.STM.TVar as Control.Concurrent.STM.TVar,
+    Rebase.Control.DeepSeq as Control.DeepSeq,
+    Rebase.Control.Exception as Control.Exception,
+    Rebase.Control.Exception.Base as Control.Exception.Base,
+    Rebase.Control.Monad as Control.Monad,
+    Rebase.Control.Monad.Cont as Control.Monad.Cont,
+    Rebase.Control.Monad.Cont.Class as Control.Monad.Cont.Class,
+    Rebase.Control.Monad.Error.Class as Control.Monad.Error.Class,
+    Rebase.Control.Monad.Fail as Control.Monad.Fail,
+    Rebase.Control.Monad.Fix as Control.Monad.Fix,
+    Rebase.Control.Monad.Identity as Control.Monad.Identity,
+    Rebase.Control.Monad.IO.Class as Control.Monad.IO.Class,
+    Rebase.Control.Monad.Reader as Control.Monad.Reader,
+    Rebase.Control.Monad.Reader.Class as Control.Monad.Reader.Class,
+    Rebase.Control.Monad.RWS as Control.Monad.RWS,
+    Rebase.Control.Monad.RWS.Class as Control.Monad.RWS.Class,
+    Rebase.Control.Monad.RWS.Lazy as Control.Monad.RWS.Lazy,
+    Rebase.Control.Monad.RWS.Strict as Control.Monad.RWS.Strict,
+    Rebase.Control.Monad.Signatures as Control.Monad.Signatures,
+    Rebase.Control.Monad.ST as Control.Monad.ST,
+    Rebase.Control.Monad.ST.Lazy as Control.Monad.ST.Lazy,
+    Rebase.Control.Monad.ST.Lazy.Unsafe as Control.Monad.ST.Lazy.Unsafe,
+    Rebase.Control.Monad.ST.Strict as Control.Monad.ST.Strict,
+    Rebase.Control.Monad.ST.Unsafe as Control.Monad.ST.Unsafe,
+    Rebase.Control.Monad.State as Control.Monad.State,
+    Rebase.Control.Monad.State.Class as Control.Monad.State.Class,
+    Rebase.Control.Monad.State.Lazy as Control.Monad.State.Lazy,
+    Rebase.Control.Monad.State.Strict as Control.Monad.State.Strict,
+    Rebase.Control.Monad.STM as Control.Monad.STM,
+    Rebase.Control.Monad.Trans as Control.Monad.Trans,
+    Rebase.Control.Monad.Trans.Class as Control.Monad.Trans.Class,
+    Rebase.Control.Monad.Trans.Cont as Control.Monad.Trans.Cont,
+    Rebase.Control.Monad.Trans.Except as Control.Monad.Trans.Except,
+    Rebase.Control.Monad.Trans.Identity as Control.Monad.Trans.Identity,
+    Rebase.Control.Monad.Trans.Maybe as Control.Monad.Trans.Maybe,
+    Rebase.Control.Monad.Trans.Reader as Control.Monad.Trans.Reader,
+    Rebase.Control.Monad.Trans.RWS as Control.Monad.Trans.RWS,
+    Rebase.Control.Monad.Trans.RWS.Lazy as Control.Monad.Trans.RWS.Lazy,
+    Rebase.Control.Monad.Trans.RWS.Strict as Control.Monad.Trans.RWS.Strict,
+    Rebase.Control.Monad.Trans.State as Control.Monad.Trans.State,
+    Rebase.Control.Monad.Trans.State.Lazy as Control.Monad.Trans.State.Lazy,
+    Rebase.Control.Monad.Trans.State.Strict as Control.Monad.Trans.State.Strict,
+    Rebase.Control.Monad.Trans.Writer as Control.Monad.Trans.Writer,
+    Rebase.Control.Monad.Trans.Writer.Lazy as Control.Monad.Trans.Writer.Lazy,
+    Rebase.Control.Monad.Trans.Writer.Strict as Control.Monad.Trans.Writer.Strict,
+    Rebase.Control.Monad.Writer as Control.Monad.Writer,
+    Rebase.Control.Monad.Writer.Class as Control.Monad.Writer.Class,
+    Rebase.Control.Monad.Writer.Lazy as Control.Monad.Writer.Lazy,
+    Rebase.Control.Monad.Writer.Strict as Control.Monad.Writer.Strict,
+    Rebase.Control.Monad.Zip as Control.Monad.Zip,
+    Rebase.Control.Selective as Control.Selective,
+    Rebase.Control.Selective.Free as Control.Selective.Free,
+    Rebase.Control.Selective.Multi as Control.Selective.Multi,
+    Rebase.Control.Selective.Rigid.Free as Control.Selective.Rigid.Free,
+    Rebase.Control.Selective.Rigid.Freer as Control.Selective.Rigid.Freer,
+    Rebase.Data.Biapplicative as Data.Biapplicative,
+    Rebase.Data.Bifoldable as Data.Bifoldable,
+    Rebase.Data.Bifunctor as Data.Bifunctor,
+    Rebase.Data.Bifunctor.Apply as Data.Bifunctor.Apply,
+    Rebase.Data.Bifunctor.Biff as Data.Bifunctor.Biff,
+    Rebase.Data.Bifunctor.Clown as Data.Bifunctor.Clown,
+    Rebase.Data.Bifunctor.Flip as Data.Bifunctor.Flip,
+    Rebase.Data.Bifunctor.Join as Data.Bifunctor.Join,
+    Rebase.Data.Bifunctor.Joker as Data.Bifunctor.Joker,
+    Rebase.Data.Bifunctor.Product as Data.Bifunctor.Product,
+    Rebase.Data.Bifunctor.Tannen as Data.Bifunctor.Tannen,
+    Rebase.Data.Bifunctor.Wrapped as Data.Bifunctor.Wrapped,
+    Rebase.Data.Bitraversable as Data.Bitraversable,
+    Rebase.Data.Bits as Data.Bits,
+    Rebase.Data.Bool as Data.Bool,
+    Rebase.Data.ByteString as Data.ByteString,
+    Rebase.Data.ByteString.Builder as Data.ByteString.Builder,
+    Rebase.Data.ByteString.Builder.Extra as Data.ByteString.Builder.Extra,
+    Rebase.Data.ByteString.Builder.Internal as Data.ByteString.Builder.Internal,
+    Rebase.Data.ByteString.Builder.Prim as Data.ByteString.Builder.Prim,
+    Rebase.Data.ByteString.Builder.Prim.Internal as Data.ByteString.Builder.Prim.Internal,
+    Rebase.Data.ByteString.Builder.Scientific as Data.ByteString.Builder.Scientific,
+    Rebase.Data.ByteString.Char8 as Data.ByteString.Char8,
+    Rebase.Data.ByteString.Internal as Data.ByteString.Internal,
+    Rebase.Data.ByteString.Lazy as Data.ByteString.Lazy,
+    Rebase.Data.ByteString.Lazy.Char8 as Data.ByteString.Lazy.Char8,
+    Rebase.Data.ByteString.Lazy.Internal as Data.ByteString.Lazy.Internal,
+    Rebase.Data.ByteString.Short as Data.ByteString.Short,
+    Rebase.Data.ByteString.Short.Internal as Data.ByteString.Short.Internal,
+    Rebase.Data.ByteString.Unsafe as Data.ByteString.Unsafe,
+    Rebase.Data.Char as Data.Char,
+    Rebase.Data.Coerce as Data.Coerce,
+    Rebase.Data.Complex as Data.Complex,
+    Rebase.Data.Data as Data.Data,
+    Rebase.Data.DList as Data.DList,
+    Rebase.Data.Dynamic as Data.Dynamic,
+    Rebase.Data.Either as Data.Either,
+    Rebase.Data.Either.Combinators as Data.Either.Combinators,
+    Rebase.Data.Either.Validation as Data.Either.Validation,
+    Rebase.Data.Eq as Data.Eq,
+    Rebase.Data.Fixed as Data.Fixed,
+    Rebase.Data.Foldable as Data.Foldable,
+    Rebase.Data.Function as Data.Function,
+    Rebase.Data.Functor as Data.Functor,
+    Rebase.Data.Functor.Alt as Data.Functor.Alt,
+    Rebase.Data.Functor.Apply as Data.Functor.Apply,
+    Rebase.Data.Functor.Bind as Data.Functor.Bind,
+    Rebase.Data.Functor.Bind.Class as Data.Functor.Bind.Class,
+    Rebase.Data.Functor.Bind.Trans as Data.Functor.Bind.Trans,
+    Rebase.Data.Functor.Classes as Data.Functor.Classes,
+    Rebase.Data.Functor.Compose as Data.Functor.Compose,
+    Rebase.Data.Functor.Constant as Data.Functor.Constant,
+    Rebase.Data.Functor.Contravariant as Data.Functor.Contravariant,
+    Rebase.Data.Functor.Contravariant.Compose as Data.Functor.Contravariant.Compose,
+    Rebase.Data.Functor.Contravariant.Divisible as Data.Functor.Contravariant.Divisible,
+    Rebase.Data.Functor.Extend as Data.Functor.Extend,
+    Rebase.Data.Functor.Identity as Data.Functor.Identity,
+    Rebase.Data.Functor.Invariant as Data.Functor.Invariant,
+    Rebase.Data.Functor.Invariant.TH as Data.Functor.Invariant.TH,
+    Rebase.Data.Functor.Plus as Data.Functor.Plus,
+    Rebase.Data.Functor.Product as Data.Functor.Product,
+    Rebase.Data.Functor.Reverse as Data.Functor.Reverse,
+    Rebase.Data.Functor.Sum as Data.Functor.Sum,
+    Rebase.Data.Graph as Data.Graph,
+    Rebase.Data.Group as Data.Group,
+    Rebase.Data.Groupoid as Data.Groupoid,
+    Rebase.Data.Hashable as Data.Hashable,
+    Rebase.Data.HashMap.Lazy as Data.HashMap.Lazy,
+    Rebase.Data.HashMap.Strict as Data.HashMap.Strict,
+    Rebase.Data.HashSet as Data.HashSet,
+    Rebase.Data.Int as Data.Int,
+    Rebase.Data.IntMap as Data.IntMap,
+    Rebase.Data.IntMap.Lazy as Data.IntMap.Lazy,
+    Rebase.Data.IntMap.Strict as Data.IntMap.Strict,
+    Rebase.Data.IntSet as Data.IntSet,
+    Rebase.Data.IORef as Data.IORef,
+    Rebase.Data.Isomorphism as Data.Isomorphism,
+    Rebase.Data.Ix as Data.Ix,
+    Rebase.Data.Kind as Data.Kind,
+    Rebase.Data.List as Data.List,
+    Rebase.Data.List.NonEmpty as Data.List.NonEmpty,
+    Rebase.Data.Map as Data.Map,
+    Rebase.Data.Map.Lazy as Data.Map.Lazy,
+    Rebase.Data.Map.Strict as Data.Map.Strict,
+    Rebase.Data.Maybe as Data.Maybe,
+    Rebase.Data.Monoid as Data.Monoid,
+    Rebase.Data.Ord as Data.Ord,
+    Rebase.Data.Profunctor as Data.Profunctor,
+    Rebase.Data.Profunctor.Adjunction as Data.Profunctor.Adjunction,
+    Rebase.Data.Profunctor.Cayley as Data.Profunctor.Cayley,
+    Rebase.Data.Profunctor.Choice as Data.Profunctor.Choice,
+    Rebase.Data.Profunctor.Closed as Data.Profunctor.Closed,
+    Rebase.Data.Profunctor.Composition as Data.Profunctor.Composition,
+    Rebase.Data.Profunctor.Mapping as Data.Profunctor.Mapping,
+    Rebase.Data.Profunctor.Monad as Data.Profunctor.Monad,
+    Rebase.Data.Profunctor.Ran as Data.Profunctor.Ran,
+    Rebase.Data.Profunctor.Rep as Data.Profunctor.Rep,
+    Rebase.Data.Profunctor.Sieve as Data.Profunctor.Sieve,
+    Rebase.Data.Profunctor.Strong as Data.Profunctor.Strong,
+    Rebase.Data.Profunctor.Traversing as Data.Profunctor.Traversing,
+    Rebase.Data.Profunctor.Types as Data.Profunctor.Types,
+    Rebase.Data.Profunctor.Unsafe as Data.Profunctor.Unsafe,
+    Rebase.Data.Profunctor.Yoneda as Data.Profunctor.Yoneda,
+    Rebase.Data.Proxy as Data.Proxy,
+    Rebase.Data.Ratio as Data.Ratio,
+    Rebase.Data.Scientific as Data.Scientific,
+    Rebase.Data.Semigroup as Data.Semigroup,
+    Rebase.Data.Semigroup.Bifoldable as Data.Semigroup.Bifoldable,
+    Rebase.Data.Semigroup.Bitraversable as Data.Semigroup.Bitraversable,
+    Rebase.Data.Semigroup.Foldable as Data.Semigroup.Foldable,
+    Rebase.Data.Semigroup.Traversable as Data.Semigroup.Traversable,
+    Rebase.Data.Semigroup.Traversable.Class as Data.Semigroup.Traversable.Class,
+    Rebase.Data.Semigroupoid as Data.Semigroupoid,
+    Rebase.Data.Semigroupoid.Dual as Data.Semigroupoid.Dual,
+    Rebase.Data.Semigroupoid.Ob as Data.Semigroupoid.Ob,
+    Rebase.Data.Semigroupoid.Static as Data.Semigroupoid.Static,
+    Rebase.Data.Sequence as Data.Sequence,
+    Rebase.Data.Set as Data.Set,
+    Rebase.Data.STRef as Data.STRef,
+    Rebase.Data.STRef.Lazy as Data.STRef.Lazy,
+    Rebase.Data.STRef.Strict as Data.STRef.Strict,
+    Rebase.Data.String as Data.String,
+    Rebase.Data.Text as Data.Text,
+    Rebase.Data.Text.Array as Data.Text.Array,
+    Rebase.Data.Text.Encoding as Data.Text.Encoding,
+    Rebase.Data.Text.Encoding.Error as Data.Text.Encoding.Error,
+    Rebase.Data.Text.Foreign as Data.Text.Foreign,
+    Rebase.Data.Text.Internal as Data.Text.Internal,
+    Rebase.Data.Text.IO as Data.Text.IO,
+    Rebase.Data.Text.Lazy as Data.Text.Lazy,
+    Rebase.Data.Text.Lazy.Builder as Data.Text.Lazy.Builder,
+    Rebase.Data.Text.Lazy.Builder.Int as Data.Text.Lazy.Builder.Int,
+    Rebase.Data.Text.Lazy.Builder.RealFloat as Data.Text.Lazy.Builder.RealFloat,
+    Rebase.Data.Text.Lazy.Builder.Scientific as Data.Text.Lazy.Builder.Scientific,
+    Rebase.Data.Text.Lazy.Encoding as Data.Text.Lazy.Encoding,
+    Rebase.Data.Text.Lazy.IO as Data.Text.Lazy.IO,
+    Rebase.Data.Text.Lazy.Read as Data.Text.Lazy.Read,
+    Rebase.Data.Text.Read as Data.Text.Read,
+    Rebase.Data.Text.Unsafe as Data.Text.Unsafe,
+    Rebase.Data.Time as Data.Time,
+    Rebase.Data.Time.Calendar as Data.Time.Calendar,
+    Rebase.Data.Time.Calendar.Easter as Data.Time.Calendar.Easter,
+    Rebase.Data.Time.Calendar.Julian as Data.Time.Calendar.Julian,
+    Rebase.Data.Time.Calendar.MonthDay as Data.Time.Calendar.MonthDay,
+    Rebase.Data.Time.Calendar.OrdinalDate as Data.Time.Calendar.OrdinalDate,
+    Rebase.Data.Time.Calendar.WeekDate as Data.Time.Calendar.WeekDate,
+    Rebase.Data.Time.Clock as Data.Time.Clock,
+    Rebase.Data.Time.Clock.POSIX as Data.Time.Clock.POSIX,
+    Rebase.Data.Time.Clock.TAI as Data.Time.Clock.TAI,
+    Rebase.Data.Time.Compat as Data.Time.Compat,
+    Rebase.Data.Time.Format as Data.Time.Format,
+    Rebase.Data.Time.Format.ISO8601 as Data.Time.Format.ISO8601,
+    Rebase.Data.Time.LocalTime as Data.Time.LocalTime,
+    Rebase.Data.Traversable as Data.Traversable,
+    Rebase.Data.Traversable.Instances as Data.Traversable.Instances,
+    Rebase.Data.Tree as Data.Tree,
+    Rebase.Data.Tuple as Data.Tuple,
+    Rebase.Data.Type.Bool as Data.Type.Bool,
+    Rebase.Data.Type.Coercion as Data.Type.Coercion,
+    Rebase.Data.Type.Equality as Data.Type.Equality,
+    Rebase.Data.Typeable as Data.Typeable,
+    Rebase.Data.Unique as Data.Unique,
+    Rebase.Data.UUID as Data.UUID,
+    Rebase.Data.Vector as Data.Vector,
+    Rebase.Data.Vector.Fusion.Stream.Monadic as Data.Vector.Fusion.Stream.Monadic,
+    Rebase.Data.Vector.Fusion.Util as Data.Vector.Fusion.Util,
+    Rebase.Data.Vector.Generic as Data.Vector.Generic,
+    Rebase.Data.Vector.Generic.Base as Data.Vector.Generic.Base,
+    Rebase.Data.Vector.Generic.Mutable as Data.Vector.Generic.Mutable,
+    Rebase.Data.Vector.Generic.New as Data.Vector.Generic.New,
+    Rebase.Data.Vector.Instances as Data.Vector.Instances,
+    Rebase.Data.Vector.Internal.Check as Data.Vector.Internal.Check,
+    Rebase.Data.Vector.Mutable as Data.Vector.Mutable,
+    Rebase.Data.Vector.Primitive as Data.Vector.Primitive,
+    Rebase.Data.Vector.Primitive.Mutable as Data.Vector.Primitive.Mutable,
+    Rebase.Data.Vector.Storable as Data.Vector.Storable,
+    Rebase.Data.Vector.Storable.Internal as Data.Vector.Storable.Internal,
+    Rebase.Data.Vector.Storable.Mutable as Data.Vector.Storable.Mutable,
+    Rebase.Data.Vector.Unboxed as Data.Vector.Unboxed,
+    Rebase.Data.Vector.Unboxed.Base as Data.Vector.Unboxed.Base,
+    Rebase.Data.Vector.Unboxed.Mutable as Data.Vector.Unboxed.Mutable,
+    Rebase.Data.Version as Data.Version,
+    Rebase.Data.Void as Data.Void,
+    Rebase.Data.Void.Unsafe as Data.Void.Unsafe,
+    Rebase.Data.Word as Data.Word,
+    Rebase.Debug.Trace as Debug.Trace,
+    Rebase.Foreign as Foreign,
+    Rebase.Foreign.C as Foreign.C,
+    Rebase.Foreign.C.Error as Foreign.C.Error,
+    Rebase.Foreign.C.String as Foreign.C.String,
+    Rebase.Foreign.C.Types as Foreign.C.Types,
+    Rebase.Foreign.Concurrent as Foreign.Concurrent,
+    Rebase.Foreign.ForeignPtr as Foreign.ForeignPtr,
+    Rebase.Foreign.ForeignPtr.Unsafe as Foreign.ForeignPtr.Unsafe,
+    Rebase.Foreign.Marshal as Foreign.Marshal,
+    Rebase.Foreign.Marshal.Alloc as Foreign.Marshal.Alloc,
+    Rebase.Foreign.Marshal.Array as Foreign.Marshal.Array,
+    Rebase.Foreign.Marshal.Error as Foreign.Marshal.Error,
+    Rebase.Foreign.Marshal.Pool as Foreign.Marshal.Pool,
+    Rebase.Foreign.Marshal.Safe as Foreign.Marshal.Safe,
+    Rebase.Foreign.Marshal.Unsafe as Foreign.Marshal.Unsafe,
+    Rebase.Foreign.Marshal.Utils as Foreign.Marshal.Utils,
+    Rebase.Foreign.Ptr as Foreign.Ptr,
+    Rebase.Foreign.StablePtr as Foreign.StablePtr,
+    Rebase.Foreign.Storable as Foreign.Storable,
+    Rebase.GHC.Arr as GHC.Arr,
+    Rebase.GHC.Base as GHC.Base,
+    Rebase.GHC.Char as GHC.Char,
+    Rebase.GHC.Conc as GHC.Conc,
+    Rebase.GHC.Conc.IO as GHC.Conc.IO,
+    Rebase.GHC.Conc.Signal as GHC.Conc.Signal,
+    Rebase.GHC.Conc.Sync as GHC.Conc.Sync,
+    Rebase.GHC.Enum as GHC.Enum,
+    Rebase.GHC.Environment as GHC.Environment,
+    Rebase.GHC.Err as GHC.Err,
+    Rebase.GHC.Exception as GHC.Exception,
+    Rebase.GHC.Exts as GHC.Exts,
+    Rebase.GHC.Fingerprint as GHC.Fingerprint,
+    Rebase.GHC.Fingerprint.Type as GHC.Fingerprint.Type,
+    Rebase.GHC.Float as GHC.Float,
+    Rebase.GHC.Float.ConversionUtils as GHC.Float.ConversionUtils,
+    Rebase.GHC.Float.RealFracMethods as GHC.Float.RealFracMethods,
+    Rebase.GHC.Foreign as GHC.Foreign,
+    Rebase.GHC.ForeignPtr as GHC.ForeignPtr,
+    Rebase.GHC.Generics as GHC.Generics,
+    Rebase.GHC.Int as GHC.Int,
+    Rebase.GHC.IO as GHC.IO,
+    Rebase.GHC.IO.Buffer as GHC.IO.Buffer,
+    Rebase.GHC.IO.BufferedIO as GHC.IO.BufferedIO,
+    Rebase.GHC.IO.Device as GHC.IO.Device,
+    Rebase.GHC.IO.Encoding as GHC.IO.Encoding,
+    Rebase.GHC.IO.Encoding.Failure as GHC.IO.Encoding.Failure,
+    Rebase.GHC.IO.Encoding.Iconv as GHC.IO.Encoding.Iconv,
+    Rebase.GHC.IO.Encoding.Latin1 as GHC.IO.Encoding.Latin1,
+    Rebase.GHC.IO.Encoding.Types as GHC.IO.Encoding.Types,
+    Rebase.GHC.IO.Encoding.UTF16 as GHC.IO.Encoding.UTF16,
+    Rebase.GHC.IO.Encoding.UTF32 as GHC.IO.Encoding.UTF32,
+    Rebase.GHC.IO.Encoding.UTF8 as GHC.IO.Encoding.UTF8,
+    Rebase.GHC.IO.Exception as GHC.IO.Exception,
+    Rebase.GHC.IO.FD as GHC.IO.FD,
+    Rebase.GHC.IO.Handle as GHC.IO.Handle,
+    Rebase.GHC.IO.Handle.FD as GHC.IO.Handle.FD,
+    Rebase.GHC.IO.Handle.Internals as GHC.IO.Handle.Internals,
+    Rebase.GHC.IO.Handle.Text as GHC.IO.Handle.Text,
+    Rebase.GHC.IO.Handle.Types as GHC.IO.Handle.Types,
+    Rebase.GHC.IO.IOMode as GHC.IO.IOMode,
+    Rebase.GHC.IOArray as GHC.IOArray,
+    Rebase.GHC.IORef as GHC.IORef,
+    Rebase.GHC.List as GHC.List,
+    Rebase.GHC.MVar as GHC.MVar,
+    Rebase.GHC.Num as GHC.Num,
+    Rebase.GHC.OverloadedLabels as GHC.OverloadedLabels,
+    Rebase.GHC.Profiling as GHC.Profiling,
+    Rebase.GHC.Ptr as GHC.Ptr,
+    Rebase.GHC.Read as GHC.Read,
+    Rebase.GHC.Real as GHC.Real,
+    Rebase.GHC.Records as GHC.Records,
+    Rebase.GHC.Show as GHC.Show,
+    Rebase.GHC.ST as GHC.ST,
+    Rebase.GHC.Stable as GHC.Stable,
+    Rebase.GHC.Stack as GHC.Stack,
+    Rebase.GHC.Stats as GHC.Stats,
+    Rebase.GHC.Storable as GHC.Storable,
+    Rebase.GHC.STRef as GHC.STRef,
+    Rebase.GHC.TopHandler as GHC.TopHandler,
+    Rebase.GHC.TypeLits as GHC.TypeLits,
+    Rebase.GHC.TypeNats as GHC.TypeNats,
+    Rebase.GHC.Unicode as GHC.Unicode,
+    Rebase.GHC.Weak as GHC.Weak,
+    Rebase.GHC.Word as GHC.Word,
+    Rebase.Numeric as Numeric,
+    Rebase.Numeric.Natural as Numeric.Natural,
+    Rebase.Prelude as Prelude,
+    Rebase.System.Console.GetOpt as System.Console.GetOpt,
+    Rebase.System.CPUTime as System.CPUTime,
+    Rebase.System.Environment as System.Environment,
+    Rebase.System.Exit as System.Exit,
+    Rebase.System.Info as System.Info,
+    Rebase.System.IO as System.IO,
+    Rebase.System.IO.Error as System.IO.Error,
+    Rebase.System.IO.Unsafe as System.IO.Unsafe,
+    Rebase.System.Mem as System.Mem,
+    Rebase.System.Mem.StableName as System.Mem.StableName,
+    Rebase.System.Mem.Weak as System.Mem.Weak,
+    Rebase.System.Posix.Internals as System.Posix.Internals,
+    Rebase.System.Posix.Types as System.Posix.Types,
+    Rebase.System.Timeout as System.Timeout,
+    Rebase.Text.ParserCombinators.ReadP as Text.ParserCombinators.ReadP,
+    Rebase.Text.ParserCombinators.ReadPrec as Text.ParserCombinators.ReadPrec,
+    Rebase.Text.Printf as Text.Printf,
+    Rebase.Text.Read as Text.Read,
+    Rebase.Text.Read.Lex as Text.Read.Lex,
+    Rebase.Text.Show as Text.Show,
+    Rebase.Unsafe.Coerce as Unsafe.Coerce,
 
   exposed:          False
   build-depends:    rebase ==1.22


### PR DESCRIPTION
Closes #4.

Hi, I attempted to do that now quite old issue.  By using `reexported-modules`, no `library/` directory is needed, and indeed no subdirectory at all.  All modules can be replaced with reexports (plus I deleted `library/GHC/PArr.hs`, which was not referenced), for a much simpler repo.  This also makes compilation much less noisy and probably faster.

It looks like this could be also done for `rebase`.  One other thought is that the roles of these two could be swapped, that is, instead have `rebase` dependent on `rerebase`, since right now modules are renamed and then renamed back.  I'm not sure if that would have other effects.

I did some basic testing of this branch, and it seems to work identically to `rerebase`.  It's possible I missed something subtle, but it's pretty simple so I don't expect so.